### PR TITLE
Add a check for data.table version before routing ifelse->fifelse

### DIFF
--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -66,10 +66,10 @@ dt_squash <- function(x, env, vars, j = TRUE) {
     } else if (is_call(x, "row_number", n = 1)) {
       arg <- dt_squash(x[[2]], vars = vars, env = env, j = j)
       expr(frank(!!arg, ties.method = "first", na.last = "keep"))
-    } else if (is_call(x, "if_else")) {
+    } else if (is_call(x, "if_else") && .global$DT_VERSION >= '1.12.4') {
       x[[1L]] <- quote(fifelse)
       x
-    } else if (is_call(x, 'coalesce')) {
+    } else if (is_call(x, 'coalesce') && .global$DT_VERSION >= '1.12.4') {
       x[[1L]] <- quote(fcoalesce)
       x
     } else if (is.function(x[[1]])) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,7 @@
 # nocov start
+.global = new.env(parent = emptyenv())
+setPackageName("dtplyr", .global)
+
 .onLoad <- function(...) {
   register_s3_method("dplyr", "filter", "data.table")
 
@@ -6,6 +9,8 @@
   register_s3_method("dplyr", "intersect", "dtplyr_step")
   register_s3_method("dplyr", "setdiff", "dtplyr_step")
   register_s3_method("dplyr", "union", "dtplyr_step")
+
+  .global$DT_VERSION = format(utils::packageVersion('data.table'))
 }
 
 register_s3_method <- function(pkg, generic, class, fun = NULL) {


### PR DESCRIPTION
Approach is to register the `data.table` version `onLoad` & keep it in a package-internal environment instead of fetching it each time in `dt_squash`.

Not sure if you have a different preferred approach for accomplishing this.

Related to #122