### PR TITLE
Enable case_when(TRUE ~ default) syntax

### DIFF
--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -110,14 +110,12 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
   } else if (is_call(x, "case_when")) {
     # case_when(x ~ y) -> fcase(x, y)
     args <- unlist(lapply(x[-1], function(x) {
-      list(x[[2]], x[[3]])
+      list(
+        if (isTRUE(x[[2]])) call2("rep", TRUE, quote(.N)) else x[[2]],
+        x[[3]]
+      )
     }))
     args <- lapply(args, dt_squash, env = env, data = data, j = j)
-    odd_index <- as.logical(seq_along(args) %% 2)
-    args[odd_index] <- lapply(
-      args[odd_index],
-      function(.x) if (isTRUE(.x)) call2("rep", TRUE, quote(.N)) else .x
-    )
     call2("fcase", !!!args)
   } else if (is_call(x, "cur_data")) {
     quote(.SD)

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -111,7 +111,9 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     # case_when(x ~ y) -> fcase(x, y)
     args <- unlist(lapply(x[-1], function(x) {
       list(
-        if (isTRUE(x[[2]])) call2("rep", TRUE, quote(.N)) else x[[2]],
+        # Get as "default" case as close as possible
+        # https://github.com/Rdatatable/data.table/issues/4258
+        if (isTRUE(x[[2]])) quote(rep(TRUE, .N)) else x[[2]],
         x[[3]]
       )
     }))

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -113,6 +113,11 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
       list(x[[2]], x[[3]])
     }))
     args <- lapply(args, dt_squash, env = env, data = data, j = j)
+    odd_index <- as.logical(seq_along(args) %% 2)
+    args[odd_index] <- lapply(
+      args[odd_index],
+      function(.x) if (isTRUE(.x)) call2("rep", TRUE, quote(.N)) else .x
+    )
     call2("fcase", !!!args)
   } else if (is_call(x, "cur_data")) {
     quote(.SD)

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -60,8 +60,8 @@ test_that("translates case_when()", {
   dt <- lazy_dt(data.frame(x = 1:10, y = 1:10))
 
   expect_equal(
-    capture_dot(dt, case_when(x1 ~ y1, x2 ~ y2)),
-    quote(fcase(x1, y1, x2, y2))
+    capture_dot(dt, case_when(x1 ~ y1, x2 ~ y2, x3 ~ TRUE, TRUE ~ y4)),
+    quote(fcase(x1, y1, x2, y2, x3, TRUE, rep(TRUE, .N), y4))
   )
 
   # translates recursively


### PR DESCRIPTION
Currently data.table [doesn't recycle the left hand side "conditions" in `fcase()`](https://github.com/Rdatatable/data.table/issues/4258). This causes `case_when(x == 1 ~ 1, TRUE ~ 2)` syntax to fail in the current translation. `fcase()` also doesn't currently allow a vector for the `default` arg.

This implements a simple workaround that is mentioned in that issue.