### PR TITLE
Don't include vars deleted in mutate() in step$vars

### DIFF
--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -1,5 +1,6 @@
 step_mutate <- function(parent, new_vars = list(), nested = FALSE) {
   vars <- union(parent$vars, names(new_vars))
+  vars <- setdiff(vars, names(new_vars)[vapply(new_vars, is_null, lgl(1))])
 
   new_step(
     parent,

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -79,6 +79,7 @@ test_that("can use across", {
 test_that("vars set correctly", {
   dt <- lazy_dt(data.frame(x = 1:3, y = 1:3))
   expect_equal(dt %>% mutate(z = 1) %>% .$vars, c("x", "y", "z"))
+  expect_equal(dt %>% mutate(x = NULL, z = 1) %>% .$vars, c("y", "z"))
 })
 
 test_that("emtpy mutate returns input", {


### PR DESCRIPTION
reprex of issue fixed
``` r
library(dtplyr)
library(dplyr)

dt <- lazy_dt(tibble(x = 1:3, y = 1:3))

step <- dt %>%
  mutate(x = NULL)

# Correct translation/output
step
#> Source: local data table [3 x 1]
#> Call:   copy(`_DT1`)[, `:=`(x = NULL)]
#> 
#>       y
#>   <int>
#> 1     1
#> 2     2
#> 3     3
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results

# Still includes dropped vars
step$vars
#> [1] "x" "y"
```

<sup>Created on 2021-02-23 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>