### PR TITLE
Allow multiple assignment to the same variable in mutate()

### DIFF
--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -20,9 +20,9 @@ dt_call.dtplyr_step_mutate <- function(x, needs_copy = x$needs_copy) {
     j <- call2(":=", !!!x$new_vars)
   } else {
     assign <- Map(function(x, y) call2("<-", x, y), syms(names(x$new_vars)), x$new_vars)
-    output <- call2(".", !!!syms(names(x$new_vars)))
+    output <- call2(".", !!!syms(unique(names(x$new_vars))))
     expr <- call2("{", !!!assign, output)
-    j <- call2(":=", call2("c", !!!names(x$new_vars)), expr)
+    j <- call2(":=", call2("c", !!!unique(names(x$new_vars))), expr)
   }
 
   out <- call2("[", dt_call(x$parent, needs_copy), , j)

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -20,9 +20,10 @@ dt_call.dtplyr_step_mutate <- function(x, needs_copy = x$needs_copy) {
     j <- call2(":=", !!!x$new_vars)
   } else {
     assign <- Map(function(x, y) call2("<-", x, y), syms(names(x$new_vars)), x$new_vars)
-    output <- call2(".", !!!syms(unique(names(x$new_vars))))
+    new_vars <- unique(names(x$new_vars))
+    output <- call2(".", !!!syms(new_vars))
     expr <- call2("{", !!!assign, output)
-    j <- call2(":=", call2("c", !!!unique(names(x$new_vars))), expr)
+    j <- call2(":=", call2("c", !!!new_vars), expr)
   }
 
   out <- call2("[", dt_call(x$parent, needs_copy), , j)

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -67,6 +67,19 @@ test_that("mutate generates compound expression if needed", {
   )
 })
 
+test_that("allows multiple assignment to the same variable", {
+  dt <- lazy_dt(data.table(x = 1, y = 2), "DT")
+
+  expect_equal(
+    dt %>% mutate(x = x * 2, x = x * 2) %>% show_query(),
+    expr(copy(DT)[, c("x") := {
+      x <- x * 2
+      x <- x * 2
+      .(x)
+    }])
+  )
+})
+
 test_that("can use across", {
   dt <- lazy_dt(data.table(x = 1, y = 2), "DT")
 


### PR DESCRIPTION
reprex of issue fixed
``` r
library(dplyr)
library(dtplyr)

df <- lazy_dt(tibble(x = rep(1, 3), y = rep(2, 3)))

df %>%
  mutate(x = x * 2,
         x = x * 2)
#> Error in `[.data.table`(copy(`_DT1`), , `:=`(c("x", "x"), {: Can't assign to the same column twice in the same query (duplicates detected).
```

<sup>Created on 2021-02-23 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>