### PR TITLE
Join by named vector

### DIFF
--- a/R/step-join.R
+++ b/R/step-join.R
@@ -219,7 +219,10 @@ join_is_simple <- function(x, y, by) {
 }
 
 join_vars <- function(x, y, on, suffixes) {
-  y <- setdiff(y, if (is_named(on)) names(on) else on)
+  on_y <- names2(on)
+  on_y[on_y == ""] <- on[on_y == ""]
+
+  y <- setdiff(y, on_y)
   vars <- union(x, y)
 
   both <- intersect(x, y)

--- a/R/step-join.R
+++ b/R/step-join.R
@@ -34,6 +34,7 @@ dt_call.dtplyr_step_join <- function(x, needs_copy = x$needs_copy) {
   lhs <- dt_call(x$parent, needs_copy)
   rhs <- dt_call(x$parent2)
   on <- call2(".", !!!syms(x$on))
+  on <- create_on_call(x$on)
 
   by.x <- as.character(x$on)
   by.y <- ifelse(names(x$on) == "", by.x, names(x$on))
@@ -53,6 +54,15 @@ dt_call.dtplyr_step_join <- function(x, needs_copy = x$needs_copy) {
   }
 
   call
+}
+
+create_on_call <- function(on) {
+  # names and values have to be swapped in the on call
+  on_swapped <- set_names(names2(on), on)
+  on_swapped[on_swapped == ""] <- on[on_swapped == ""]
+  on_swapped <- simplify_names(on_swapped)
+
+  call2(".", !!!syms(on_swapped))
 }
 
 # dplyr verbs -------------------------------------------------------------


### PR DESCRIPTION
Fixes #222 

The question is what to do about the wrong column order:

i) always use `step_colorder()`: this is trivial
ii) only call `step_colorder()` when needed: this makes the code a bit more complicated
iii) do not use `merge()` but always `[` to join: this gets rid of the distinction between "simple" and "non-simple" joins and would thus probably simplify the code. This would still sometimes require calling `step_colorder()`. It would probably make sense to follow along what is done [`tidytable`](https://github.com/markfairbanks/tidytable/blob/main/R/join.R). So, if you'd like to go for this option maybe @markfairbanks wants to make a PR for this.