### PR TITLE
Allow usage of default `.cols` in `across()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,9 @@
 * `.data` and `.env` pronouns now work inside of `if_else()` (@markfairbanks, #220).
 
 * `arrange(dt, desc(col))` is now translated to `dt[order(-col)]` in order to utilize
-`data.table`'s fast order.
+`data.table`'s fast order (@markfairbanks, #227).
+
+* `across()` now defaults to `.cols = everything()` when `.cols` isn't provided (@markfairbanks, #231).
 
 * More translations for tidyr verbs have been added:
   

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -7,7 +7,8 @@ dt_squash_across <- function(call, env, data, j = j) {
   call <- match.call(dplyr::across, call, expand.dots = FALSE, envir = env)
 
   tbl <- simulate_vars(data, drop_groups = TRUE)
-  locs <- tidyselect::eval_select(call$.cols, tbl, allow_rename = FALSE)
+  .cols <- call$.cols %||% expr(everything())
+  locs <- tidyselect::eval_select(.cols, tbl, allow_rename = FALSE)
   cols <- syms(names(tbl))[locs]
 
   funs <- across_funs(call$.fns, env, data, j = j)

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -87,6 +87,11 @@ test_that("can use across", {
     dt %>% mutate(across(everything(), ~ . + 1)) %>% show_query(),
     expr(copy(DT)[, `:=`(x = x + 1, y = y + 1)])
   )
+
+  expect_equal(
+    dt %>% mutate(across(.fns = ~ . + 1)) %>% show_query(),
+    expr(copy(DT)[, `:=`(x = x + 1, y = y + 1)])
+  )
 })
 
 test_that("vars set correctly", {


### PR DESCRIPTION
reprex of issue fixed:
``` r
library(dtplyr)
library(dplyr)

test_df <- tibble(x = 1:3, y = 1:3)

lazy_dt(test_df) %>%
  mutate(across(.fns = ~ .x + 1))
#> Error: Can't rename variables in this context.
```