### PR TITLE
Translated named args in `if_else()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,8 +34,7 @@ Suggests:
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),
-    tidyr (>= 1.1.0),
-    withr
+    tidyr (>= 1.1.0)
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,8 @@ Suggests:
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),
-    tidyr (>= 1.1.0)
+    tidyr (>= 1.1.0),
+    withr
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@
 
 * `tally()` is now translated (@mgirlich, #201).
 
+* Named arguments in `if_else()` are translated to the correct arguments in `data.table::fifelse()` 
+(@markfairbanks, #234)
+
 * `ifelse()` is now mapped to `fifelse()` (@markfairbanks, #220).
 
 * `.data` and `.env` pronouns now work inside of `if_else()` (@markfairbanks, #220).

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -104,7 +104,7 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     } else if (is_symbol(x[[2]], ".env")) {
       sym(paste0("..", var))
     }
-  } else if (is_call(x, "coalesce") || is_call(x, "replace_na")) {
+  } else if (is_call(x, c("coalesce", "replace_na"))) {
     x[[1L]] <- quote(fcoalesce)
     x
   } else if (is_call(x, "case_when")) {
@@ -133,7 +133,7 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x[[1]] <- sym("-")
     x[[2]] <- get_expr(x[[2]])
     x
-  } else if (is_call(x, "if_else") || is_call(x, "ifelse")) {
+  } else if (is_call(x, c("if_else", "ifelse"))) {
     x[[1L]] <- quote(fifelse)
     names(x) <- if_else_args[names(x)]
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)
@@ -153,7 +153,10 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
   }
 }
 
-if_else_args <- c("condition" = "test", "true" = "yes", "false" = "no", "missing" = "na")
+if_else_args <- c(
+  "condition" = "test", "true" = "yes", "false" = "no", "missing" = "na",
+  "yes" = "yes", "no" = "no"
+)
 
 is_mask_pronoun <- function(x) {
   is_call(x, c("$", "[["), n = 2) && is_symbol(x[[2]], c(".data", ".env"))

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -155,7 +155,7 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
 
 if_else_args <- c(
   "condition" = "test", "true" = "yes", "false" = "no", "missing" = "na",
-  "yes" = "yes", "no" = "no"
+  "test" = "test", "yes" = "yes", "no" = "no"
 )
 
 is_mask_pronoun <- function(x) {

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -135,6 +135,7 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x
   } else if (is_call(x, "if_else") || is_call(x, "ifelse")) {
     x[[1L]] <- quote(fifelse)
+    names(x) <- if_else_args[names(x)]
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)
     x
   } else if (is_call(x, "n", n = 0)) {
@@ -151,6 +152,8 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x
   }
 }
+
+if_else_args <- c("condition" = "test", "true" = "yes", "false" = "no", "missing" = "na")
 
 is_mask_pronoun <- function(x) {
   is_call(x, c("$", "[["), n = 2) && is_symbol(x[[2]], c(".data", ".env"))

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -136,6 +136,8 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
   } else if (is_call(x, c("if_else", "ifelse"))) {
     if (is_call(x, "if_else")) {
       x <- unname(match.call(dplyr::if_else, x))
+    } else {
+      x <- unname(match.call(ifelse, x))
     }
 
     x[[1]] <- quote(fifelse)

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -134,8 +134,11 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x[[2]] <- get_expr(x[[2]])
     x
   } else if (is_call(x, c("if_else", "ifelse"))) {
-    x[[1L]] <- quote(fifelse)
-    names(x) <- if_else_args[names(x)]
+    if (is_call(x, "if_else")) {
+      x <- unname(match.call(dplyr::if_else, x))
+    }
+
+    x[[1]] <- quote(fifelse)
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)
     x
   } else if (is_call(x, "n", n = 0)) {
@@ -152,11 +155,6 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x
   }
 }
-
-if_else_args <- c(
-  "condition" = "test", "true" = "yes", "false" = "no", "missing" = "na",
-  "test" = "test", "yes" = "yes", "no" = "no"
-)
 
 is_mask_pronoun <- function(x) {
   is_call(x, c("$", "[["), n = 2) && is_symbol(x[[2]], c(".data", ".env"))

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -193,9 +193,10 @@ test_that("mask if_else/ifelse & coalesce with data.table versions", {
     dt %>% mutate(y = if_else(x < 3, 1, 2)) %>% show_query(),
     expr(copy(DT)[, `:=`(y = fifelse(x < 3, 1, 2))])
   )
+  # if_else works with named args, partial named args, and odd argument order
   expect_equal(
-    dt %>% mutate(y = if_else(condition = x < 3, true = 1, false = 2, missing = NA)) %>% show_query(),
-    expr(copy(DT)[, `:=`(y = fifelse(test = x < 3, yes = 1, no = 2, na = NA))])
+    dt %>% mutate(y = if_else(x < 3, false = 2, tr = 1, missing = NA)) %>% show_query(),
+    expr(copy(DT)[, `:=`(y = fifelse(x < 3, 1, 2, NA))])
   )
   expect_equal(
     dt %>% mutate(y = ifelse(x < 3, 1, 2)) %>% show_query(),

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -194,6 +194,10 @@ test_that("mask if_else/ifelse & coalesce with data.table versions", {
     expr(copy(DT)[, `:=`(y = fifelse(x < 3, 1, 2))])
   )
   expect_equal(
+    dt %>% mutate(y = if_else(condition = x < 3, true = 1, false = 2, missing = NA)) %>% show_query(),
+    expr(copy(DT)[, `:=`(y = fifelse(test = x < 3, yes = 1, no = 2, na = NA))])
+  )
+  expect_equal(
     dt %>% mutate(y = ifelse(x < 3, 1, 2)) %>% show_query(),
     expr(copy(DT)[, `:=`(y = fifelse(x < 3, 1, 2))])
   )

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -58,8 +58,7 @@ test_that("translate context functions", {
 
 
 test_that("translates if_else()/ifelse()", {
-  old <- options(warnPartialMatchArgs = FALSE)
-  on.exit(options(old))
+  withr::local_options(warnPartialMatchArgs = FALSE)
 
   df <- data.frame(x = 1:5)
 

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -58,7 +58,8 @@ test_that("translate context functions", {
 
 
 test_that("translates if_else()/ifelse()", {
-  withr::local_options(warnPartialMatchArgs = FALSE)
+  old <- options(warnPartialMatchArgs = FALSE)
+  on.exit(options(old))
 
   df <- data.frame(x = 1:5)
 

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -58,8 +58,6 @@ test_that("translate context functions", {
 
 
 test_that("translates if_else()/ifelse()", {
-  withr::local_options(warnPartialMatchArgs = FALSE)
-
   df <- data.frame(x = 1:5)
 
   expect_equal(


### PR DESCRIPTION
reprex of issue fixed:

``` r
library(data.table)
library(dplyr)
library(dtplyr)

test_df <- data.table(x = c("a", "a", "b", NA))

test_df %>%
  mutate(if_x = if_else(x == "a", true = 1, false = 0, missing = NULL))
#> Error in fifelse(x == "a", true = 1, false = 0, missing = NULL): unused arguments (true = 1, false = 0, missing = NULL)
```