### PR TITLE
Group transmute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * `group_by()` now ungroups when no grouping variables are specified (@mgirlich, #248).
   
 * `transmute()` and `mutate()` without any variables now work (@mgirlich, #248).
+
 * `ungroup()` removes variables in `...` from grouping (@mgirlich, #253).
 
 * `filter()` works for negated logical columns (@mgirlich, @211).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dtplyr (development version)
 
+* `transmute()` doesn't produce duplicate columns when assigning to the same
+  variable (@mgirlich, #249).
+
 * `group_by(dt, y = x)` now works (@mgirlich, #246).
 
 * Group columns can now be mutated instead of creating another column with the

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # dtplyr (development version)
 
+* `group_by(dt, y = x)` now works (@mgirlich, #246).
+
+* Group columns can now be mutated instead of creating another column with the
+  same name (@mgirlich, #246).
+  
+* Grouping variables can now be selected after a `transmute()` (@mgirlich, #246).
+
+* `group_by()` now ungroups when no grouping variables are specified (@mgirlich, #248).
+  
+* `transmute()` and `mutate()` without any variables now work (@mgirlich, #248).
 
 * `filter()` works for negated logical columns (@mgirlich, @211).
 

--- a/R/step-group.R
+++ b/R/step-group.R
@@ -78,7 +78,12 @@ group_by.dtplyr_step <- function(.data, ..., .add = FALSE, add = deprecated(), a
     .add <- add
   }
 
-  existing <- vapply(dots, is_symbol, logical(1))
+  existing <- purrr::imap_lgl(
+    dots,
+    function(x, name) {
+      is_symbol(x) && (as_name(x) == name)
+    }
+  )
   if (!all(existing)) {
     .data <- mutate(.data, !!!dots[!existing])
     dots[!existing] <- syms(names(dots[!existing]))

--- a/R/step-group.R
+++ b/R/step-group.R
@@ -89,7 +89,7 @@ group_by.dtplyr_step <- function(.data, ..., .add = FALSE, add = deprecated(), a
     dots[!existing] <- syms(names(dots[!existing]))
   }
 
-  groups <- c(if (.add) .data$groups, names(dots))
+  groups <- c(if (.add) .data$groups, names(dots)) %||% character()
   arranged <- if (!is.null(.data$arrange)) .data$arrange && arrange else arrange
 
   step_group(.data, groups, arranged)

--- a/R/step-group.R
+++ b/R/step-group.R
@@ -78,12 +78,16 @@ group_by.dtplyr_step <- function(.data, ..., .add = FALSE, add = deprecated(), a
     .add <- add
   }
 
-  existing <- purrr::imap_lgl(
-    dots,
-    function(x, name) {
+  existing <- vapply(
+    seq_along(dots),
+    function(i) {
+      x <- dots[[i]]
+      name <- names(dots)[[i]]
       is_symbol(x) && (as_name(x) == name)
-    }
+    },
+    logical(1)
   )
+
   if (!all(existing)) {
     .data <- mutate(.data, !!!dots[!existing])
     dots[!existing] <- syms(names(dots[!existing]))

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -56,11 +56,10 @@ dt_call.dtplyr_step_mutate <- function(x, needs_copy = x$needs_copy) {
 #' dt %>%
 #'   mutate(x1 = x + 1, x2 = x1 + 1)
 mutate.dtplyr_step <- function(.data, ...) {
-  if (missing(...)) {
+  dots <- capture_dots(.data, ...)
+  if (is_null(dots)) {
     return(.data)
   }
-
-  dots <- capture_dots(.data, ...)
 
   nested <- nested_vars(.data, dots, .data$vars)
   step_mutate(.data, dots, nested)

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -19,16 +19,24 @@ dt_call.dtplyr_step_mutate <- function(x, needs_copy = x$needs_copy) {
   if (!x$nested) {
     j <- call2(":=", !!!x$new_vars)
   } else {
-    assign <- Map(function(x, y) call2("<-", x, y), syms(names(x$new_vars)), x$new_vars)
-    new_vars <- unique(names(x$new_vars))
-    output <- call2(".", !!!syms(new_vars))
-    expr <- call2("{", !!!assign, output)
-    j <- call2(":=", call2("c", !!!new_vars), expr)
+    mutate_list <- mutate_nested_vars(x$new_vars)
+    j <- call2(":=", call2("c", !!!mutate_list$new_vars), mutate_list$expr)
   }
 
   out <- call2("[", dt_call(x$parent, needs_copy), , j)
 
   add_grouping_param(out, x, arrange = FALSE)
+}
+
+mutate_nested_vars <- function(mutate_vars) {
+  assign <- Map(function(x, y) call2("<-", x, y), syms(names(mutate_vars)), mutate_vars)
+  new_vars <- unique(names(mutate_vars))
+  output <- call2(".", !!!syms(new_vars))
+
+  list(
+    expr = call2("{", !!!assign, output),
+    new_vars = new_vars
+  )
 }
 
 # dplyr methods -----------------------------------------------------------

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -29,7 +29,7 @@ dt_call.dtplyr_step_mutate <- function(x, needs_copy = x$needs_copy) {
 }
 
 mutate_nested_vars <- function(mutate_vars) {
-  assign <- Map(function(x, y) call2("<-", x, y), syms(names(mutate_vars)), mutate_vars)
+  assign <- map2(syms(names(mutate_vars)), mutate_vars, function(x, y) call2("<-", x, y))
   new_vars <- unique(names(mutate_vars))
   output <- call2(".", !!!syms(new_vars))
 

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -30,8 +30,11 @@ transmute.dtplyr_step <- function(.data, ...) {
   }
 
   if (is_empty(dots)) {
-    # TODO suppress message: "Adding missing grouping variables"
-    return(select(.data))
+    # grouping variables have been removed from `dots` so `select()` would
+    # produce a message "Adding grouping vars".
+    # As `dplyr::transmute()` doesn't generate a message when adding group vars
+    # we can also leave it away here
+    return(select(.data, !!!group_vars(.data)))
   }
 
   if (!nested) {

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -18,6 +18,8 @@ transmute.dtplyr_step <- function(.data, ...) {
 
   groups <- group_vars(.data)
   if (!is_empty(groups)) {
+    # TODO could check if there is actually anything mutated, e.g. to avoid
+    # DT[, .(x = x)]
     is_group_var <- names(dots) %in% groups
     group_dots <- dots[is_group_var]
 
@@ -25,6 +27,10 @@ transmute.dtplyr_step <- function(.data, ...) {
     .data <- group_by(.data, !!!syms(groups))
 
     dots <- dots[!is_group_var]
+  }
+
+  if (is_empty(dots)) {
+    return(.data)
   }
 
   if (!nested) {

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -30,7 +30,8 @@ transmute.dtplyr_step <- function(.data, ...) {
   }
 
   if (is_empty(dots)) {
-    return(.data)
+    # TODO suppress message: "Adding missing grouping variables"
+    return(select(.data))
   }
 
   if (!nested) {

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -36,9 +36,7 @@ transmute.dtplyr_step <- function(.data, ...) {
   if (!nested) {
     j <- call2(".", !!!dots)
   } else {
-    assign <- Map(function(x, y) call2("<-", x, y), syms(names(dots)), dots)
-    output <- call2(".", !!!syms(set_names(names(dots))))
-    j <- call2("{", !!!assign, output)
+    j <- mutate_nested_vars(dots)$expr
   }
   vars <- union(group_vars(.data), names(dots))
   step_subset_j(.data, vars = vars, j = j)

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -23,7 +23,8 @@ transmute.dtplyr_step <- function(.data, ...) {
     output <- call2(".", !!!syms(set_names(names(dots))))
     j <- call2("{", !!!assign, output)
   }
-  step_subset_j(.data, vars = names(dots), j = j)
+  vars <- union(group_vars(.data), names(dots))
+  step_subset_j(.data, vars = vars, j = j)
 }
 
 #' @export

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -16,8 +16,8 @@ transmute.dtplyr_step <- function(.data, ...) {
   dots <- capture_dots(.data, ...)
   nested <- nested_vars(.data, dots, .data$vars)
 
-  if (!nested) {
-    groups <- group_vars(.data)
+  groups <- group_vars(.data)
+  if (!is_empty(groups)) {
     is_group_var <- names(dots) %in% groups
     group_dots <- dots[is_group_var]
 
@@ -25,6 +25,9 @@ transmute.dtplyr_step <- function(.data, ...) {
     .data <- group_by(.data, !!!syms(groups))
 
     dots <- dots[!is_group_var]
+  }
+
+  if (!nested) {
     j <- call2(".", !!!dots)
   } else {
     assign <- Map(function(x, y) call2("<-", x, y), syms(names(dots)), dots)

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -17,6 +17,14 @@ transmute.dtplyr_step <- function(.data, ...) {
   nested <- nested_vars(.data, dots, .data$vars)
 
   if (!nested) {
+    groups <- group_vars(.data)
+    is_group_var <- names(dots) %in% groups
+    group_dots <- dots[is_group_var]
+
+    .data <- mutate(ungroup(.data), !!!group_dots)
+    .data <- group_by(.data, !!!syms(groups))
+
+    dots <- dots[!is_group_var]
     j <- call2(".", !!!dots)
   } else {
     assign <- Map(function(x, y) call2("<-", x, y), syms(names(dots)), dots)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,1 +1,15 @@
 cat_line <- function(...) cat(paste(..., "\n", collapse = "", sep = ""))
+
+# nocov start - compat-purrr.R
+
+map2 <- function(.x, .y, .f, ...) {
+  .f <- as_function(.f, env = global_env())
+  out <- mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
+  if (length(out) == length(.x)) {
+    set_names(out, names(.x))
+  } else {
+    set_names(out, NULL)
+  }
+}
+
+# nocov end

--- a/tests/testthat/test-step-group.R
+++ b/tests/testthat/test-step-group.R
@@ -69,3 +69,9 @@ test_that("`key` switches between keyby= and by=", {
     expr(DT1[, .(mean_mpg = mean(mpg)), keyby = .(cyl)])
   )
 })
+
+test_that("emtpy group_by ungroups", {
+  dt <- lazy_dt(data.frame(x = 1)) %>% group_by(x)
+  expect_equal(group_by(dt) %>% group_vars(), character())
+  expect_equal(group_by(dt, !!!list()) %>% group_vars(), character())
+})

--- a/tests/testthat/test-step-group.R
+++ b/tests/testthat/test-step-group.R
@@ -33,6 +33,12 @@ test_that("grouping can compute new variables if needed", {
     expr(copy(DT)[, `:=`(xy = x + y)])
   )
 
+  # also works when RHS is only a symbol
+  expect_equal(
+    dt %>% group_by(z = x) %>% show_query(),
+    expr(copy(DT)[, `:=`(z = x)])
+  )
+
   expect_equal(
     dt %>% group_by(xy = x + y) %>% summarise(x = mean(x)) %>% show_query(),
     expr(copy(DT)[, `:=`(xy = x + y)][, .(x = mean(x)), keyby = .(xy)])

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -103,4 +103,5 @@ test_that("vars set correctly", {
 test_that("emtpy mutate returns input", {
   dt <- lazy_dt(data.frame(x = 1))
   expect_equal(mutate(dt), dt)
+  expect_equal(mutate(dt, !!!list()), dt)
 })

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -15,10 +15,24 @@ test_that("transmute generates compound expression if needed", {
     expr(DT[, {
       x2 <- x * 2
       x4 <- x2 * 2
-      .(x2 = x2, x4 = x4)
+      .(x2, x4)
     }])
   )
 })
+
+test_that("allows multiple assignment to the same variable", {
+  dt <- lazy_dt(data.table(x = 1, y = 2), "DT")
+
+  expect_equal(
+    dt %>% transmute(x = x * 2, x = x * 2) %>% show_query(),
+    expr(DT[, {
+      x <- x * 2
+      x <- x * 2
+      .(x)
+    }])
+  )
+})
+
 
 test_that("groups are respected", {
   dt <- lazy_dt(data.table(x = 1), "DT") %>% group_by(x) %>% transmute(y = 2)

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -29,3 +29,25 @@ test_that("groups are respected", {
     expr(DT[, .(y = 2), keyby = .(x)])
   )
 })
+
+test_that("grouping vars can be transmuted", {
+  dt <- lazy_dt(data.table(x = 1), "DT") %>% group_by(x) %>% transmute(x = x + 1, y = 2)
+
+  expect_equal(dt$vars, c("x", "y"))
+  expect_equal(dt$groups, "x")
+  expect_equal(
+    dt %>% show_query(),
+    expr(copy(DT)[, `:=`(x = x + 1)][, .(y = 2), keyby = .(x)])
+  )
+
+  skip("transmuting grouping vars with nesting is not supported")
+  dt <- lazy_dt(data.table(x = 1), "DT") %>%
+    group_by(x) %>%
+    transmute(x = x + 1, y = x + 1, x = y + 1)
+
+  expect_equal(dt$vars, c("x", "y"))
+  expect_equal(
+    dt %>% collect(),
+    tibble(x = 4, y = 3) %>% group_by(x)
+  )
+})

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -51,3 +51,14 @@ test_that("grouping vars can be transmuted", {
     tibble(x = 4, y = 3) %>% group_by(x)
   )
 })
+
+test_that("empty transmute returns input", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(transmute(dt), dt)
+  expect_equal(transmute(dt, !!!list()), dt)
+})
+
+test_that("only transmuting groups works", {
+  dt <- lazy_dt(data.frame(x = 1)) %>% group_by(x)
+  expect_equal(transmute(dt, x) %>% collect(), dt %>% collect())
+})

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -66,13 +66,18 @@ test_that("grouping vars can be transmuted", {
   )
 })
 
-test_that("empty transmute returns input", {
-  dt <- lazy_dt(data.frame(x = 1))
-  expect_equal(transmute(dt), dt)
-  expect_equal(transmute(dt, !!!list()), dt)
+test_that("empty transmute works", {
+  dt <- lazy_dt(data.frame(x = 1), "DT")
+  expect_equal(transmute(dt) %>% show_query(), expr(DT[, 0L]))
+  expect_equal(transmute(dt)$vars, character())
+  expect_equal(transmute(dt, !!!list()) %>% show_query(), expr(DT[, 0L]))
+
+  dt_grouped <- lazy_dt(data.frame(x = 1), "DT") %>% group_by(x)
+  expect_equal(transmute(dt_grouped)$vars, "x")
 })
 
 test_that("only transmuting groups works", {
   dt <- lazy_dt(data.frame(x = 1)) %>% group_by(x)
   expect_equal(transmute(dt, x) %>% collect(), dt %>% collect())
+  expect_equal(transmute(dt, x)$vars, "x")
 })

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -19,3 +19,13 @@ test_that("transmute generates compound expression if needed", {
     }])
   )
 })
+
+test_that("groups are respected", {
+  dt <- lazy_dt(data.table(x = 1), "DT") %>% group_by(x) %>% transmute(y = 2)
+
+  expect_equal(dt$vars, c("x", "y"))
+  expect_equal(
+    dt %>% show_query(),
+    expr(DT[, .(y = 2), keyby = .(x)])
+  )
+})


### PR DESCRIPTION
Fixes #246, fixes #248, and fixes #249.

What doesn't work is `transmute()` on a grouping variable when also using nesting

``` r
library(dplyr, warn.conflicts = FALSE)
devtools::load_all("~/GitHub/dtplyr/")
#> ℹ Loading dtplyr

dt <- lazy_dt(tibble(x = 1, y = 2), "DT")
dt %>% 
  group_by(x) %>% 
  transmute(x = x * 2, y = x + 2, x = y * 4) %>% 
  show_query()
#> copy(DT)[, `:=`(x = x * 2, x = y * 4)][, {
#>     y <- x + 2
#>     .(y = y)
#> }, keyby = .(x)]
```

<sup>Created on 2021-05-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

But this feels like quite an edge case to me and something that one shouldn't really do anyway...