### PR TITLE
Support `name` argument in `pull()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dtplyr (development version)
 
+* `pull()` now supports the `name` argument (@mgirlich, #263).
+
 * `left_join()`, `right_join()`, `full_join()`, and `inner_join()` perform a
   cross join for `by = character()` (@mgirlich, #242).
   

--- a/R/step.R
+++ b/R/step.R
@@ -157,14 +157,22 @@ as_tibble.dtplyr_step <- function(x, ..., .name_repair = "check_unique") {
 
 #' @export
 #' @importFrom dplyr pull
-pull.dtplyr_step <- function(.data, var = -1) {
-  expr <- enquo(var)
-  var <- dplyr:::find_var(expr, .data$vars)
+pull.dtplyr_step <- function(.data, var = -1, name = NULL) {
+  var <- sym(tidyselect::vars_pull(.data$vars, !!enquo(var)))
 
   .data <- ungroup(.data)
-  .data <- select(.data, !! sym(var))
-  .data <- collect(.data)
-  .data[[1]]
+
+  name <- enquo(name)
+  if (quo_is_null(name)) {
+    .data <- select(.data, !! var)
+    .data <- collect(.data)
+    .data[[1]]
+  } else {
+    name <- sym(tidyselect::vars_pull(.data$vars, !!name))
+    .data <- select(.data, !! var, !! name)
+    .data <- collect(.data)
+    set_names(.data[[1]], .data[[2]])
+  }
 }
 
 #' @export

--- a/tests/testthat/test-step.R
+++ b/tests/testthat/test-step.R
@@ -54,3 +54,30 @@ test_that("collect and compute return grouped data", {
   expect_equal(dt %>% compute() %>% group_vars(), "x")
   expect_equal(dt %>% collect() %>% group_vars(), "x")
 })
+
+
+# pull() ------------------------------------------------------------------
+
+test_that("pull default extracts last var from data frame", {
+  df <- lazy_dt(tibble(x = 1:10, y = 1:10), "DT")
+  expect_equal(pull(df), 1:10)
+})
+
+test_that("can extract by name, or positive/negative position", {
+  x <- 1:10
+  df <- lazy_dt(tibble(x = x, y = runif(10)), "DT")
+
+  expect_equal(pull(df, x), x)
+  expect_equal(pull(df, 1), x)
+  expect_equal(pull(df, -2L), x)
+})
+
+test_that("can extract named vectors", {
+  x <- 1:10
+  y <- letters[x]
+  df <- lazy_dt(tibble(x = x, y = y), "DT")
+  xn <- set_names(x, y)
+
+  expect_equal(pull(df, x, y), xn)
+  expect_equal(pull(df, 1, 2), xn)
+})


### PR DESCRIPTION
This fixes accidentally the example with `select_if()` provided in #258. I skimmed over `dplyr::select_if()` and this might be very inefficient but as `select_if()` and friends are superseded this probably doesn't matter much.