### PR TITLE
Support the `.groups` argument in `summarise()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dtplyr (development version)
 
+* `summarise()` now supports the `.groups` argument (@mgirlich, #245).
+
 * `pull()` now supports the `name` argument (@mgirlich, #263).
 
 * @mgirlich is now a dtplyr author in recognition of his significant and

--- a/R/step-subset-summarise.R
+++ b/R/step-subset-summarise.R
@@ -7,6 +7,18 @@
 #' @param .data A [lazy_dt()].
 #' @inheritParams dplyr::summarise
 #' @importFrom dplyr summarise
+#' @param .groups \Sexpr[results=rd]{lifecycle::badge("experimental")} Grouping structure of the result.
+#'
+#'   * "drop_last": dropping the last level of grouping. This was the
+#'   only supported option before version 1.0.0.
+#'   * "drop": All levels of grouping are dropped.
+#'   * "keep": Same grouping structure as `.data`.
+#'
+#'   When `.groups` is not specified, it defaults to "drop_last".
+#'
+#'   In addition, a message informs you of that choice, unless the result is ungrouped,
+#'   the option "dplyr.summarise.inform" is set to `FALSE`,
+#'   or when `summarise()` is called from a function in a package.
 #' @export
 #' @examples
 #' library(dplyr, warn.conflicts = FALSE)
@@ -20,7 +32,7 @@
 #' dt %>%
 #'   group_by(cyl) %>%
 #'   summarise(across(disp:wt, mean))
-summarise.dtplyr_step <- function(.data, ...) {
+summarise.dtplyr_step <- function(.data, ..., .groups = NULL) {
   dots <- capture_dots(.data, ...)
   check_summarise_vars(dots)
 
@@ -39,13 +51,14 @@ summarise.dtplyr_step <- function(.data, ...) {
     )
   }
 
-  step_group(out, groups = head(.data$groups, -1))
+  out_groups <- summarise_groups(.data, .groups, caller_env())
+  step_group(out, groups = out_groups)
 }
 
 #' @export
-summarise.data.table <- function(.data, ...) {
+summarise.data.table <- function(.data, ..., .groups = NULL) {
   .data <- lazy_dt(.data)
-  summarise(.data, ...)
+  summarise(.data, ..., .groups = .groups)
 }
 
 
@@ -63,4 +76,44 @@ check_summarise_vars <- function(dots) {
       ))
     }
   }
+}
+
+summarise_groups <- function(.data, .groups, env_caller) {
+  if (!is.null(.groups) && !.groups %in% c("drop_last", "drop", "keep")) {
+    abort(c(
+      paste0(
+        "`.groups` can't be ", as_label(.groups),
+        if (.groups == "rowwise") " in dtplyr"
+      ),
+      i = 'Possible values are NULL (default), "drop_last", "drop", and "keep"'
+    ))
+  }
+
+  group_vars <- .data$groups
+  n <- length(group_vars)
+
+  verbose <- summarise_verbose(.groups, env_caller)
+  if (verbose && n > 1) {
+    new_groups <- glue::glue_collapse(paste0("'", group_vars[-n], "'"), sep = ", ")
+    summarise_inform("has grouped output by {new_groups}")
+  }
+
+  .groups <- .groups %||% "drop_last"
+  switch(.groups,
+    drop_last = group_vars[-n],
+    keep = group_vars,
+    drop = character()
+  )
+}
+
+summarise_verbose <- function(.groups, .env) {
+  is.null(.groups) &&
+    is_reference(topenv(.env), global_env()) &&
+    !identical(getOption("dplyr.summarise.inform"), FALSE)
+}
+
+summarise_inform <- function(..., .env = parent.frame()) {
+  inform(paste0(
+    "`summarise()` ", glue::glue(..., .envir = .env), '. You can override using the `.groups` argument.'
+  ))
 }

--- a/man/left_join.dtplyr_step.Rd
+++ b/man/left_join.dtplyr_step.Rd
@@ -44,8 +44,8 @@ These are methods for the dplyr generics \code{\link[=left_join]{left_join()}}, 
 inner, and anti join are translated to the \verb{[.data.table} equivalent,
 full joins to \code{\link[data.table:merge]{data.table::merge.data.table()}}.
 Left, right, and full joins are in some cases followed by calls to
-\code{\link[data.table:setcolorder]{data.table::setcolorder()}} and \code{\link[data.table:setattr]{data.table::setnames()}} to ensure correct
-column order and names.
+\code{\link[data.table:setcolorder]{data.table::setcolorder()}} and \code{\link[data.table:setattr]{data.table::setnames()}} to ensure that column
+order and names match dplyr conventions.
 Semi-joins don't have a direct data.table equivalent.
 }
 \examples{

--- a/man/summarise.dtplyr_step.Rd
+++ b/man/summarise.dtplyr_step.Rd
@@ -4,7 +4,7 @@
 \alias{summarise.dtplyr_step}
 \title{Summarise each group to one row}
 \usage{
-\method{summarise}{dtplyr_step}(.data, ...)
+\method{summarise}{dtplyr_step}(.data, ..., .groups = NULL)
 }
 \arguments{
 \item{.data}{A \code{\link[=lazy_dt]{lazy_dt()}}.}
@@ -18,6 +18,20 @@ The value can be:
 \item A vector of length \code{n}, e.g. \code{quantile()}.
 \item A data frame, to add multiple columns from a single expression.
 }}
+
+\item{.groups}{\Sexpr[results=rd]{lifecycle::badge("experimental")} Grouping structure of the result.
+\itemize{
+\item "drop_last": dropping the last level of grouping. This was the
+only supported option before version 1.0.0.
+\item "drop": All levels of grouping are dropped.
+\item "keep": Same grouping structure as \code{.data}.
+}
+
+When \code{.groups} is not specified, it defaults to "drop_last".
+
+In addition, a message informs you of that choice, unless the result is ungrouped,
+the option "dplyr.summarise.inform" is set to \code{FALSE},
+or when \code{summarise()} is called from a function in a package.}
 }
 \description{
 This is a method for the dplyr \code{\link[=summarise]{summarise()}} generic. It is translated to

--- a/tests/testthat/_snaps/step-subset-summarise.md
+++ b/tests/testthat/_snaps/step-subset-summarise.md
@@ -1,0 +1,15 @@
+# summarise(.groups=)
+
+    Code
+      eval_bare(expr(lazy_dt(data.frame(x = 1, y = 2), "DT") %>% group_by(x, y) %>%
+        dplyr::summarise() %>% show_query()), env(global_env()))
+    Message <message>
+      `summarise()` has grouped output by 'x'. You can override using the `.groups` argument.
+    Output
+      unique(DT)
+
+---
+
+    `.groups` can't be "rowwise" in dtplyr
+    i Possible values are NULL (default), "drop_last", "drop", and "keep"
+

--- a/tests/testthat/test-step-subset-summarise.R
+++ b/tests/testthat/test-step-subset-summarise.R
@@ -75,3 +75,30 @@ test_that("if for unsupported resummarise", {
   dt <- lazy_dt(data.frame(x = 1:3, y = 1:3))
   expect_error(dt %>% summarise(x = mean(x), x2 = sd(x)), "mutate")
 })
+
+test_that("summarise(.groups=)", {
+  # the `dplyr::` prefix is needed for `check()`
+  # should produce a message when called directly by user
+  expect_message(eval_bare(
+    expr(lazy_dt(data.frame(x = 1, y = 2), "DT") %>% group_by(x, y) %>% dplyr::summarise() %>% show_query()),
+    env(global_env())
+  ))
+  expect_snapshot(eval_bare(
+    expr(lazy_dt(data.frame(x = 1, y = 2), "DT") %>% group_by(x, y) %>% dplyr::summarise() %>% show_query()),
+    env(global_env())
+  ))
+
+  # should be silent when called in another package
+  expect_silent(eval_bare(
+    expr(lazy_dt(data.frame(x = 1, y = 2), "DT") %>% group_by(x, y) %>% dplyr::summarise() %>% show_query()),
+    asNamespace("testthat")
+  ))
+
+  df <- lazy_dt(data.table(x = 1, y = 2), "DT") %>% group_by(x, y)
+  expect_equal(df %>% summarise() %>% group_vars(), "x")
+  expect_equal(df %>% summarise(.groups = "drop_last") %>% group_vars(), "x")
+  expect_equal(df %>% summarise(.groups = "drop") %>% group_vars(), character())
+  expect_equal(df %>% summarise(.groups = "keep") %>% group_vars(), c("x", "y"))
+
+  expect_snapshot_error(df %>% summarise(.groups = "rowwise"))
+})


### PR DESCRIPTION
Fixes #245. The code is mostly copied from `dbplyr` 😄 