### PR TITLE
`filter()` checks for names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dtplyr (development version)
 
+* `filter()` now errors for named input like dplyr (@mgirlich, #267).
+
 * `pull()` now supports the `name` argument (@mgirlich, #263).
 
 * @mgirlich is now a dtplyr author in recognition of his significant and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # dtplyr (development version)
 
-* `filter()` now errors for named input like dplyr (@mgirlich, #267).
+* `filter()` now errors for named input, e.g. `filter(dt, x = 1)` (@mgirlich, #267).
 
 * `pull()` now supports the `name` argument (@mgirlich, #263).
 

--- a/R/step-nest.R
+++ b/R/step-nest.R
@@ -38,7 +38,7 @@ nest.dtplyr_step <- function(.data, ..., .names_sep = NULL, .key = deprecated())
     j_exprs <- imap(
       cols,
       function(x, name) {
-        x <- simplify_names2(x)
+        x <- simplify_names(x)
         expr(.(data.table(!!!syms(x))))
       }
     )
@@ -80,11 +80,4 @@ eval_nest_dots <- function(.data, ...) {
     sim_data <- simulate_vars(.data)
     lapply(cols, function(.x) names(tidyselect::eval_select(.x, sim_data)))
   }
-}
-
-simplify_names2 <- function(x) {
-  auto_names <- rlang::exprs_auto_name(x)
-  name_unnecessary <- names2(x) == auto_names
-  names(x)[name_unnecessary] <- ""
-  x
 }

--- a/tests/testthat/_snaps/step-subset-filter.md
+++ b/tests/testthat/_snaps/step-subset-filter.md
@@ -1,0 +1,20 @@
+# errors for named input
+
+    Code
+      filter(dt, x = 1)
+    Error <rlang_error>
+      Problem with `filter()` input `..1`.
+      x Input `..1` is named.
+      i This usually means that you've used `=` instead of `==`.
+      i Did you mean `x == 1`?
+
+---
+
+    Code
+      filter(dt, y > 1, x = 1)
+    Error <rlang_error>
+      Problem with `filter()` input `..2`.
+      x Input `..2` is named.
+      i This usually means that you've used `=` instead of `==`.
+      i Did you mean `x == 1`?
+

--- a/tests/testthat/test-step-subset-filter.R
+++ b/tests/testthat/test-step-subset-filter.R
@@ -98,3 +98,24 @@ test_that("only adds step if dots are not empty", {
   expect_equal(dt %>% filter(), dt)
   expect_equal(dt %>% filter(!!!list()), dt)
 })
+
+test_that("errors for named input", {
+  dt <- lazy_dt(data.table(x = 1, y = 2), "DT")
+
+  expect_snapshot(error = TRUE, filter(dt, x = 1))
+  expect_snapshot(error = TRUE, filter(dt, y > 1, x = 1))
+})
+
+test_that("allows named constants that resolve to logical vectors", {
+  dt <- lazy_dt(mtcars, "DT")
+  filters <- mtcars %>%
+    transmute(
+      cyl %in% 6:8,
+      hp / drat > 50
+    )
+
+  expect_equal(
+    filter(dt, !!!filters),
+    filter(dt, !!!unname(filters))
+  )
+})


### PR DESCRIPTION
Fixes #267.
And it removes a function that was necessary in the first iterations of `nest()` but is now useless (and the logic did only work accidentally).