### PR TITLE
desc() checks the number of arguments.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,6 @@
 # dtplyr (development version)
 
-* `tally()` and `count()` now follow the dplyr convention of creating a unique 
-  name if the default output `name` (n) already exists (@eutwt, #295).
-
-* Fixed a bug which prevented changing the value of a group variable with
-  `summarise()`, `tally()`, or `count()` (@eutwt, #295).
+* `desc()` now gives an error if more than one argument is provided (@eutwt #285).
 
 * `if_any()` and `if_all()` now default to `.cols = everything()` when `.cols` 
   isn't provided (@eutwt, #294).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # dtplyr (development version)
 
-* `desc()` now gives an error if more than one argument is provided (@eutwt #285).
+* `tally()` and `count()` now follow the dplyr convention of creating a unique 
+  name if the default output `name` (n) already exists (@eutwt, #295).
+
+* Fixed a bug which prevented changing the value of a group variable with
+  `summarise()`, `tally()`, or `count()` (@eutwt, #295).
 
 * `if_any()` and `if_all()` now default to `.cols = everything()` when `.cols` 
   isn't provided (@eutwt, #294).

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -130,6 +130,9 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
   } else if (is_call(x, "cur_group_rows")) {
     quote(.I)
   } else if (is_call(x, "desc")) {
+      if (!has_length(x, 2L)) {
+        abort("`desc()` expects exactly one argument.")
+      }
     x[[1]] <- sym("-")
     x[[2]] <- get_expr(x[[2]])
     x

--- a/tests/testthat/_snaps/tidyeval.md
+++ b/tests/testthat/_snaps/tidyeval.md
@@ -5,7 +5,7 @@
 # desc() checks the number of arguments
 
     Code
-      capture_dots(df, desc(a, b))
+      capture_dot(df, desc(a, b))
     Error <rlang_error>
       `desc()` expects exactly one argument.
 

--- a/tests/testthat/_snaps/tidyeval.md
+++ b/tests/testthat/_snaps/tidyeval.md
@@ -2,3 +2,10 @@
 
     The `order_by` argument of `lag()` is not supported by dtplyr
 
+# desc() checks the number of arguments
+
+    Code
+      capture_dots(df, desc(a, b))
+    Error <rlang_error>
+      `desc()` expects exactly one argument.
+

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -263,7 +263,7 @@ test_that("`desc(col)` is translated to `-col` inside arrange", {
 })
 
 test_that("desc() checks the number of arguments", {
-  expect_snapshot(error = TRUE, capture_dots(df, desc(a, b)))
+  expect_snapshot(error = TRUE, capture_dot(df, desc(a, b)))
 })
 
 test_that("n_distinct() is translated to uniqueN()", {

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -262,6 +262,10 @@ test_that("`desc(col)` is translated to `-col` inside arrange", {
   expect_equal(out$x, c("b", "a"))
 })
 
+test_that("desc() checks the number of arguments", {
+  expect_snapshot(error = TRUE, capture_dots(df, desc(a, b)))
+})
+
 test_that("n_distinct() is translated to uniqueN()", {
   # Works with multiple inputs
   expect_equal(


### PR DESCRIPTION
Currently if you pass two arguments to `desc` as in `desc(a, b)`, it is converted to `a - b` by `dt_squash_call`. This PR adds a check to error if more than one argument is provided. 

A similar issue was fixed in dplyr: https://github.com/tidyverse/dplyr/pull/5929

Before this PR:

``` r
library(dplyr, warn.conflicts = FALSE)
library(dtplyr, warn.conflicts = FALSE)

dt <- lazy_dt(data.frame(a = rep(1:2, each = 2), b = 1:4))

dt %>% 
  arrange(desc(a, b))
#> Source: local data table [4 x 2]
#> Call:   `_DT1`[order(a - b)]
#> 
#>       a     b
#>   <int> <int>
#> 1     2     4
#> 2     1     2
#> 3     2     3
#> 4     1     1
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```

<sup>Created on 2021-08-22 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

After this PR:

``` r
library(dplyr, warn.conflicts = FALSE)
library(dtplyr, warn.conflicts = FALSE)

dt <- lazy_dt(data.frame(a = rep(1:2, each = 2), b = 1:4))

dt %>% 
  arrange(desc(a, b))
#> Error: `desc()` expects exactly one argument.
```

<sup>Created on 2021-08-22 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

