### PR TITLE
Allow functions and formulas with non-call RHS in `across`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -94,6 +94,12 @@
   
   * `separate()` (@markfairbanks, #269)
 
+* `across()` now handles `.fns` arguments provided in the forms listed below. (@eutwt #288)
+
+  * Anonymous functions, such as `function(x) x + 1`
+
+  * Formulas which don't require a function call, such as `~ 1`
+
 # dtplyr 1.1.0
 
 ## New features

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -60,6 +60,8 @@ dt_squash_if <- function(call, env, data, j = j, reduce = "&") {
 across_funs <- function(funs, env, data, j = TRUE) {
   if (is.null(funs)) {
     list(function(x, ...) x)
+  } else if (is_function(funs)) {
+    set_names(list(function(x, ...) call2(funs, x, ...)), 'anon')
   } else if (is_symbol(funs)) {
     set_names(list(across_fun(funs, env, data, j = j)), as.character(funs))
   } else if (is.character(funs)) {
@@ -75,7 +77,7 @@ across_funs <- function(funs, env, data, j = TRUE) {
     funs <- eval(funs, env)
     across_funs(funs, NULL)
   } else {
-    abort("`.fns` argument to dtplyr::across() must be a NULL, a function name, formula, or list")
+    abort("`.fns` argument to dtplyr::across() must be a NULL, a function, formula, or list")
   }
 }
 

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -96,7 +96,9 @@ across_fun <- function(fun, env, data, j = TRUE) {
 dt_squash_formula <- function(x, env, data, j = TRUE, replace = quote(!!.x)) {
   call <- f_rhs(x)
   call <- replace_dot(call, replace)
-  call <- dt_squash_call(call, env, data, j = j)
+  if (is_call(call)) {
+    call <- dt_squash_call(call, env, data, j = j)
+  }
   call
 }
 

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -61,7 +61,7 @@ across_funs <- function(funs, env, data, j = TRUE) {
   if (is.null(funs)) {
     list(function(x, ...) x)
   } else if (is_function(funs)) {
-    set_names(list(function(x, ...) call2(funs, x, ...)), 'anon')
+    set_names(list(across_fun(funs, env, data, j = j)), 'anonymous_function')
   } else if (is_symbol(funs)) {
     set_names(list(across_fun(funs, env, data, j = j)), as.character(funs))
   } else if (is.character(funs)) {
@@ -82,14 +82,15 @@ across_funs <- function(funs, env, data, j = TRUE) {
 }
 
 across_fun <- function(fun, env, data, j = TRUE) {
-  if (is_symbol(fun) || is_string(fun)) {
+  if (is_symbol(fun) || is_string(fun) ||
+    is_call(fun, "function") || is_function(fun)) {
     function(x, ...) call2(fun, x, ...)
   } else if (is_call(fun, "~")) {
     call <- dt_squash_formula(fun, env, data, j = j, replace = quote(!!.x))
     function(x, ...) expr_interp(call, child_env(emptyenv(), .x = x))
   } else {
     abort(c(
-      ".fns argument to dtplyr::across() must contain a function name or a formula",
+      ".fns argument to dtplyr::across() must contain a function or a formula",
       x = paste0("Problem with ", expr_deparse(fun))
     ))
   }

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -60,10 +60,8 @@ dt_squash_if <- function(call, env, data, j = j, reduce = "&") {
 across_funs <- function(funs, env, data, j = TRUE) {
   if (is.null(funs)) {
     list(function(x, ...) x)
-  } else if (is_function(funs)) {
-    set_names(list(across_fun(funs, env, data, j = j)), 'anonymous_function')
-  } else if (is_symbol(funs)) {
-    set_names(list(across_fun(funs, env, data, j = j)), as.character(funs))
+  } else if (is_symbol(funs) || is_function(funs)) {
+    set_names(list(across_fun(funs, env, data, j = j)), as_label(funs))
   } else if (is.character(funs)) {
     names(funs)[names2(funs) == ""] <- funs
     lapply(funs, across_fun, env, data, j = j)

--- a/tests/testthat/_snaps/tidyeval-across.md
+++ b/tests/testthat/_snaps/tidyeval-across.md
@@ -3,10 +3,10 @@
     Code
       capture_across(dt, across(a, 1))
     Error <rlang_error>
-      `.fns` argument to dtplyr::across() must be a NULL, a function name, formula, or list
+      `.fns` argument to dtplyr::across() must be a NULL, a function, formula, or list
     Code
       capture_across(dt, across(a, list(1)))
     Error <rlang_error>
-      .fns argument to dtplyr::across() must contain a function name or a formula
+      .fns argument to dtplyr::across() must contain a function or a formula
       x Problem with 1
 

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -58,6 +58,17 @@ test_that("across() translates functions", {
   )
 })
 
+test_that("across() captures anonymous functions", {
+  dt <- lazy_dt(data.frame(a = 1))
+
+  expect_equal(
+   capture_across(dt, across(a, function(x) log(x))),
+   quo_squash(list(
+     a = call2(function(x) log(x), quote(a))
+   ))
+  )
+})
+
 test_that("dots are translated too", {
   fun <- function() {
     dt <- lazy_dt(data.frame(a = 1, b = 2))

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -63,9 +63,7 @@ test_that("across() captures anonymous functions", {
 
   expect_equal(
    capture_across(dt, across(a, function(x) log(x))),
-   quo_squash(list(
-     a = call2(function(x) log(x), quote(a))
-   ))
+   quo_squash(list(a = call2(function(x) log(x), quote(a))))
   )
 })
 

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -83,6 +83,11 @@ test_that("across() translates formulas", {
   )
 
   expect_equal(
+    capture_across(dt, across(a:b, ~2)),
+    exprs(a = 2, b = 2)
+  )
+
+  expect_equal(
     capture_across(dt, across(a:b, list(~log(.x)))),
     exprs(a = log(a), b = log(b))
   )

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -63,7 +63,7 @@ test_that("across() captures anonymous functions", {
 
   expect_equal(
    capture_across(dt, across(a, function(x) log(x))),
-   quo_squash(list(a = call2(function(x) log(x), quote(a))))
+   list(a = call2(function(x) log(x), quote(a)))
   )
 })
 


### PR DESCRIPTION
This PR does two things. Included together since they're both expanding possible `across` inputs and both pretty small changes.

1. Skips `dt_squash_call` for formulas whose RHS is not a call, allowing such formulas in `across`
- Behavior of non-call formulas in master shown here: #287  
2. Allows anonymous non-formula functions in across

I could separate these if needed (and if there's interest in accepting either of them)

``` r
library(dplyr, warn.conflicts = FALSE)
library(dtplyr, warn.conflicts = FALSE)

lazy_dt(data.frame(a = 1, b = 2)) %>% 
  mutate(across(a, ~ b)) %>% 
  as_tibble()
#> # A tibble: 1 × 2
#>       a     b
#>   <dbl> <dbl>
#> 1     2     2

lazy_dt(data.frame(a = 1, b = 2)) %>% 
  mutate(across(a:b, function(x) x + 1)) %>% 
  as_tibble()
#> # A tibble: 1 × 2
#>       a     b
#>   <dbl> <dbl>
#> 1     2     3
```

<sup>Created on 2021-08-27 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
