### PR TITLE
Simplify `expand`

### DIFF
--- a/R/step-subset-expand.R
+++ b/R/step-subset-expand.R
@@ -57,9 +57,11 @@ expand.dtplyr_step <- function(data, ..., .name_repair = "check_unique") {
   }
   names(dots) <- vctrs::vec_as_names(names(dots), repair = .name_repair)
 
-  j <- expr(CJ(!!!dots, unique = TRUE))
-
-  out <- step_subset(data, j = j, vars = c(data$groups, names(dots)))
+  out <- step_subset_j(
+    data,
+    j = expr(CJ(!!!dots, unique = TRUE)),
+    vars = c(data$groups, names(dots))
+  )
   out
 }
 

--- a/R/step-subset-expand.R
+++ b/R/step-subset-expand.R
@@ -59,7 +59,9 @@ expand.dtplyr_step <- function(data, ..., .name_repair = "check_unique") {
   dots_names <- names(dots)
 
   out <- step_subset_j(
-    data, j = expr(CJ(!!!dots, unique = TRUE)), vars = c(data$groups, dots_names)
+    data, 
+    vars = union(data$groups, dots_names),
+    j = expr(CJ(!!!dots, unique = TRUE))
   )
 
   # Delete duplicate columns if group vars are expanded
@@ -68,7 +70,7 @@ expand.dtplyr_step <- function(data, ..., .name_repair = "check_unique") {
     expanded_group_vars <- dots_names[dots_names %in% group_vars]
 
     out <- step_subset(
-      out, j = expr(!!expanded_group_vars := NULL), groups = character()
+      out, groups = character(), j = expr(!!expanded_group_vars := NULL)
     )
     out <- group_by(out, !!!syms(group_vars))
   }

--- a/R/step-subset-expand.R
+++ b/R/step-subset-expand.R
@@ -57,17 +57,9 @@ expand.dtplyr_step <- function(data, ..., .name_repair = "check_unique") {
   }
   names(dots) <- vctrs::vec_as_names(names(dots), repair = .name_repair)
 
-  on <- names(dots)
-  cj <- expr(CJ(!!!syms(on), unique = TRUE))
+  j <- expr(CJ(!!!dots, unique = TRUE))
 
-  out <- distinct(data, !!!syms(data$groups), !!!dots)
-  if (length(data$groups) == 0) {
-    out <- step_subset(out, i = cj, on = on)
-  } else {
-    on <- call2(".", !!!syms(on))
-    out <- step_subset(out, j = expr(.SD[!!cj, on = !!on]))
-  }
-
+  out <- step_subset(data, j = j, vars = c(data$groups, names(dots)))
   out
 }
 

--- a/tests/testthat/test-step-subset-expand.R
+++ b/tests/testthat/test-step-subset-expand.R
@@ -6,7 +6,7 @@ test_that("expand completes all values", {
 
   expect_equal(
     show_query(step),
-    expr(unique(DT)[CJ(x, y, unique = TRUE), on = .(x, y)])
+    expr(DT[, CJ(x = x, y = y, unique = TRUE)])
   )
   expect_equal(step$vars, c("x", "y"))
   expect_equal(nrow(out), 4)
@@ -29,7 +29,7 @@ test_that("works with unnamed vectors", {
 
   expect_equal(
     show_query(step),
-    expr(unique(DT[, .(x = x, V2 = 1:2)])[CJ(x, V2, unique = TRUE), on = .(x, V2)])
+    expr(DT[, CJ(x = x, V2 = 1:2, unique = TRUE)])
   )
   expect_equal(step$vars, c("x", "V2"))
   expect_equal(nrow(out), 4)
@@ -43,7 +43,7 @@ test_that("works with named vectors", {
 
   expect_equal(
     show_query(step),
-    expr(unique(DT[, .(x = x, val = 1:2)])[CJ(x, val, unique = TRUE), on = .(x, val)])
+    expr(DT[, CJ(x = x, val = 1:2, unique = TRUE)])
   )
   expect_equal(step$vars, c("x", "val"))
   expect_equal(nrow(out), 4)
@@ -61,7 +61,7 @@ test_that("expand respects groups", {
 
   expect_equal(
     show_query(step),
-    expr(unique(DT[, .(c, a, b)])[, .SD[CJ(a, b, unique = TRUE), on = .(a, b)], keyby = .(c)])
+    expr(DT[, CJ(a = a, b = b, unique = TRUE), keyby = .(c)])
   )
   expect_equal(step$vars, c("c", "a", "b"))
   expect_equal(out$a, c(1, 1, 2, 2, 1))


### PR DESCRIPTION
It looks like `expand` can be simplified so that it's just a `CJ` in `j` (plus careful name construction). I changed expected expressions in the tests, but all the outputs are unchanged. 

I see that you did the original implementation @markfairbanks, so I'd appreciate it if you could take a look and tell me whether there's some cases not handled correctly in the simplified version.

Example with a lot of groups:

```r
# expand1 = dtplyr master
# expand2 = This PR

library(dplyr)
library(bench)
library(data.table)
library(dtplyr)

df <-
  data.table(grpvar = rep(1:1e4, each = 10)) %>% 
    group_by(grpvar) %>%
    mutate(numvar = sample(50, n(), T),
           charvar = sample(c(rownames(mtcars), state.name), n(), TRUE)) %>%
    as.data.table()

#### Example with group_by

out_expand1 <- df %>% group_by(grpvar) %>% expand1(numvar, charvar) %>% as.data.table()
out_expand2 <- df %>% group_by(grpvar) %>% expand2(numvar, charvar) %>% as.data.table()

identical(out_expand1, out_expand2)
# [1] TRUE

mark(
  out_expand1 = df %>% group_by(grpvar) %>% expand1(numvar, charvar) %>% as.data.table(),
  out_expand2 = df %>% group_by(grpvar) %>% expand2(numvar, charvar) %>% as.data.table(),
  check = FALSE
)
# # A tibble: 2 × 13
#   expression       min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory
#   <bch:expr>  <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>
# 1 out_expand1    9.32s  9.32s     0.107    1.01GB     1.39     1    13      9.32s <NULL> <Rpro…
# 2 out_expand2    1.67s  1.67s     0.597  202.68MB     2.39     1     4      1.67s <NULL> <Rpro…
# # … with 2 more variables: time <list>, gc <list>


#### Example without group_by

out_expand1 <- df %>% expand1(grpvar, numvar, charvar) %>% as.data.table()
out_expand2 <- df %>% expand2(grpvar, numvar, charvar) %>% as.data.table()

identical(out_expand1, setkey(out_expand2, NULL))
# [1] TRUE

mark(
  out_expand1 = df %>% expand1(grpvar, numvar, charvar) %>% as.data.table(),
  out_expand2 = df %>% expand2(grpvar, numvar, charvar) %>% as.data.table(),
  check = FALSE
)
# # A tibble: 2 × 13
#   expression       min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory
#   <bch:expr>  <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>
# 1 out_expand1    2.35s  2.35s     0.426    2.14GB        0     1     0      2.35s <NULL> <Rpro…
# 2 out_expand2    1.15s  1.15s     0.873   783.3MB        0     1     0      1.15s <NULL> <Rpro…
# # … with 2 more variables: time <list>, gc <list>
```