### PR TITLE
Add `.before` and `.after` arguments to `mutate`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -94,6 +94,10 @@
   
   * `separate()` (@markfairbanks, #269)
 
+* `mutate()` gains experimental new arguments `.before` and `.after` that allow 
+   you to control where the new columns are placed (as added in dplyr 1.0.0) 
+   (@eutwt #291).
+
 # dtplyr 1.1.0
 
 ## New features

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -44,12 +44,18 @@ mutate_nested_vars <- function(mutate_vars) {
 #' Create and modify columns
 #'
 #' This is a method for the dplyr [mutate()] generic. It is translated to
-#' the `j` argument of `[.data.table`, using `:=` to modify "in place".
+#' the `j` argument of `[.data.table`, using `:=` to modify "in place". If 
+#' `.before` or `.after` is provided, the new columns are relocated with a call
+#' to [data.table::setcolorder()].
 #'
 #' @param .data A [lazy_dt()].
 #' @param ... <[data-masking][dplyr::dplyr_data_masking]> Name-value pairs.
 #'   The name gives the name of the column in the output, and the value should
 #'   evaluate to a vector.
+#' @param .before,.after \Sexpr[results=rd]{lifecycle::badge("experimental")}
+#'   <[`tidy-select`][dplyr_tidy_select]> Optionally, control where new columns
+#'   should appear (the default is to add to the right hand side). See
+#'   [relocate()] for more details.
 #' @importFrom dplyr mutate
 #' @export
 #' @examples
@@ -63,14 +69,25 @@ mutate_nested_vars <- function(mutate_vars) {
 #' # are used in the same expression
 #' dt %>%
 #'   mutate(x1 = x + 1, x2 = x1 + 1)
-mutate.dtplyr_step <- function(.data, ...) {
+mutate.dtplyr_step <- function(.data, ...,
+                               .before = NULL, .after = NULL) {
   dots <- capture_dots(.data, ...)
   if (is_null(dots)) {
     return(.data)
   }
 
   nested <- nested_vars(.data, dots, .data$vars)
-  step_mutate(.data, dots, nested)
+  out <- step_mutate(.data, dots, nested)
+
+  .before <- enquo(.before)
+  .after <- enquo(.after)
+  if (!quo_is_null(.before) || !quo_is_null(.after)) {
+    # Only change the order of new columns
+    new <- setdiff(names(dots), .data$vars)
+    out <- relocate(out, !!new, .before = !!.before, .after = !!.after)
+  }
+
+  out
 }
 
 #' @export

--- a/man/mutate.dtplyr_step.Rd
+++ b/man/mutate.dtplyr_step.Rd
@@ -4,7 +4,7 @@
 \alias{mutate.dtplyr_step}
 \title{Create and modify columns}
 \usage{
-\method{mutate}{dtplyr_step}(.data, ...)
+\method{mutate}{dtplyr_step}(.data, ..., .before = NULL, .after = NULL)
 }
 \arguments{
 \item{.data}{A \code{\link[=lazy_dt]{lazy_dt()}}.}
@@ -12,10 +12,17 @@
 \item{...}{<\link[dplyr:dplyr_data_masking]{data-masking}> Name-value pairs.
 The name gives the name of the column in the output, and the value should
 evaluate to a vector.}
+
+\item{.before, .after}{\Sexpr[results=rd]{lifecycle::badge("experimental")}
+<\code{\link[=dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns
+should appear (the default is to add to the right hand side). See
+\code{\link[=relocate]{relocate()}} for more details.}
 }
 \description{
 This is a method for the dplyr \code{\link[=mutate]{mutate()}} generic. It is translated to
-the \code{j} argument of \verb{[.data.table}, using \verb{:=} to modify "in place".
+the \code{j} argument of \verb{[.data.table}, using \verb{:=} to modify "in place". If
+\code{.before} or \code{.after} is provided, the new columns are relocated with a call
+to \code{\link[data.table:setcolorder]{data.table::setcolorder()}}.
 }
 \examples{
 library(dplyr, warn.conflicts = FALSE)

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -105,3 +105,27 @@ test_that("emtpy mutate returns input", {
   expect_equal(mutate(dt), dt)
   expect_equal(mutate(dt, !!!list()), dt)
 })
+
+# .before and .after -----------------------------------------------------------
+
+test_that("can use .before and .after to control column position", {
+  dt <- lazy_dt(data.frame(x = 1, y = 2))
+  expect_named(
+    mutate(dt, z = 1) %>% as_tibble(),
+    c("x", "y", "z")
+  )
+  expect_named(
+    mutate(dt, z = 1, .before = x) %>% as_tibble(),
+    c("z", "x", "y")
+    )
+  expect_named(
+    mutate(dt, z = 1, .after = x) %>% as_tibble(),
+    c("x", "z", "y")
+    )
+
+  # but doesn't affect order of existing columns
+  expect_named(
+    mutate(dt, x = 1, .after = y) %>% as_tibble(),
+    c("x", "y")
+    )
+})

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -117,15 +117,15 @@ test_that("can use .before and .after to control column position", {
   expect_named(
     mutate(dt, z = 1, .before = x) %>% as_tibble(),
     c("z", "x", "y")
-    )
+  )
   expect_named(
     mutate(dt, z = 1, .after = x) %>% as_tibble(),
     c("x", "z", "y")
-    )
+  )
 
   # but doesn't affect order of existing columns
   expect_named(
     mutate(dt, x = 1, .after = y) %>% as_tibble(),
     c("x", "y")
-    )
+  )
 })


### PR DESCRIPTION
Example with this PR loaded:

``` r
library(dtplyr)
library(dplyr, warn.conflicts = FALSE)

lazy_dt(data.frame(x = 1, y = 1)) %>% 
  mutate(z = 1, .before = y)
#> Source: local data table [1 x 3]
#> Call:   setcolorder(copy(`_DT1`)[, `:=`(z = 1)], c("x", "z", "y"))
#> 
#>       x     z     y
#>   <dbl> <dbl> <dbl>
#> 1     1     1     1
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```

<sup>Created on 2021-08-29 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>