### PR TITLE
Document `expand()` output with unrealized factor levels

### DIFF
--- a/R/step-subset-expand.R
+++ b/R/step-subset-expand.R
@@ -2,7 +2,8 @@
 #'
 #' @description
 #' This is a method for the tidyr `expand()` generic. It is translated to
-#' [data.table::CJ()].
+#' [data.table::CJ()]. Unlike the data.frame method, this method only retains
+#' factor levels present in the data.
 #'
 #' @param data A [lazy_dt()].
 #' @inheritParams tidyr::expand
@@ -20,13 +21,10 @@
 #' ))
 #'
 #' # Factors ----------------------------------------------------------
-#' # The output of `expand(<dtplyr_step>)` only contains levels of factor 
-#' # variables present in the data. This is in contrast to the output of 
-#' # `expand()` when the input is a data.frame, which retains all factor levels.
-#' # Using the `fruits` data, the level "L" is not be present in `expand()` 
-#' # output, unlike the output of `expand()` after converting `fruits()` to a
-#' # tibble.
-#' 
+#' # When called on `fruits` defined above, the level "L" is not present in
+#' # the output of `expand(fruits, size)`, unlike the output of `expand()` when
+#' # `fruits` is a data.frame.
+#'
 #' fruits %>% expand(size) %>% as_tibble()
 #' #> # A tibble: 3 × 1
 #' #>   size
@@ -54,6 +52,7 @@
 #' # Use with `right_join()` to fill in missing rows
 #' fruits %>% dplyr::right_join(all)
 # exported onLoad
+
 expand.dtplyr_step <- function(data, ..., .name_repair = "check_unique") {
   dots <- capture_dots(data, ..., .j = FALSE)
   dots <- dots[!vapply(dots, is_null, logical(1))]

--- a/R/step-subset-expand.R
+++ b/R/step-subset-expand.R
@@ -19,12 +19,29 @@
 #'   weights = rnorm(6, as.numeric(size) + 2)
 #' ))
 #'
-#' # All possible combinations ---------------------------------------
-#' # Note that all defined, but not necessarily present, levels of the
-#' # factor variable `size` are retained.
-#' fruits %>% expand(type)
-#' fruits %>% expand(type, size)
-#' fruits %>% expand(type, size, year)
+#' # Factors ----------------------------------------------------------
+#' # The output of `expand(<dtplyr_step>)` only contains levels of factor 
+#' # variables present in the data. This is in contrast to the output of 
+#' # `expand()` when the input is a data.frame, which retains all factor levels.
+#' # Using the `fruits` data, the level "L" is not be present in `expand()` 
+#' # output, unlike the output of `expand()` after converting `fruits()` to a
+#' # tibble.
+#' 
+#' fruits %>% expand(size) %>% as_tibble()
+#' #> # A tibble: 3 × 1
+#' #>   size
+#' #>   <fct>
+#' #> 1 XS
+#' #> 2 S
+#' #> 3 M
+#' fruits %>% as_tibble() %>% expand(size)
+#' #> # A tibble: 4 × 1
+#' #>   size
+#' #>   <fct>
+#' #> 1 XS
+#' #> 2 S
+#' #> 3 M
+#' #> 4 L
 #'
 #' # Other uses -------------------------------------------------------
 #' fruits %>% expand(type, size, 2010:2012)

--- a/R/step-subset-expand.R
+++ b/R/step-subset-expand.R
@@ -52,7 +52,6 @@
 #' # Use with `right_join()` to fill in missing rows
 #' fruits %>% dplyr::right_join(all)
 # exported onLoad
-
 expand.dtplyr_step <- function(data, ..., .name_repair = "check_unique") {
   dots <- capture_dots(data, ..., .j = FALSE)
   dots <- dots[!vapply(dots, is_null, logical(1))]

--- a/man/expand.dtplyr_step.Rd
+++ b/man/expand.dtplyr_step.Rd
@@ -49,7 +49,8 @@ to enforce them.}
 }
 \description{
 This is a method for the tidyr \code{expand()} generic. It is translated to
-\code{\link[data.table:J]{data.table::CJ()}}.
+\code{\link[data.table:J]{data.table::CJ()}}. Unlike the data.frame method, this method only retains
+factor levels present in the data.
 }
 \examples{
 library(tidyr)
@@ -64,12 +65,26 @@ fruits <- lazy_dt(tibble(
   weights = rnorm(6, as.numeric(size) + 2)
 ))
 
-# All possible combinations ---------------------------------------
-# Note that all defined, but not necessarily present, levels of the
-# factor variable `size` are retained.
-fruits \%>\% expand(type)
-fruits \%>\% expand(type, size)
-fruits \%>\% expand(type, size, year)
+# Factors ----------------------------------------------------------
+# When called on `fruits` defined above, the level "L" is not present in
+# the output of `expand(fruits, size)`, unlike the output of `expand()` when
+# `fruits` is a data.frame.
+
+fruits \%>\% expand(size) \%>\% as_tibble()
+#> # A tibble: 3 × 1
+#>   size
+#>   <fct>
+#> 1 XS
+#> 2 S
+#> 3 M
+fruits \%>\% as_tibble() \%>\% expand(size)
+#> # A tibble: 4 × 1
+#>   size
+#>   <fct>
+#> 1 XS
+#> 2 S
+#> 3 M
+#> 4 L
 
 # Other uses -------------------------------------------------------
 fruits \%>\% expand(type, size, 2010:2012)


### PR DESCRIPTION
As requested in #290. I'm not too familiar with tidyverse documentation standards so it would be understandable if you'd rather change it yourself.

See #250 for ideas on how to support unrealized factor levels in dtplyr. 

Until then, this PR is adding documentation to explain the difference from the data.frame method (and removing the previous incorrect documentation). Not sure if the example showcasing the difference is needed.