### PR TITLE
`across()` handles named selections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # dtplyr (development version)
 
-* `across()` handles named selections (@eutwt #293)
+* `across()` handles named selections (@eutwt #293).
 
 * `summarise()` now supports the `.groups` argument (@mgirlich, #245).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dtplyr (development version)
 
+* `across()` handles named selections (@eutwt #293)
+
 * `summarise()` now supports the `.groups` argument (@mgirlich, #245).
 
 * `filter()` now errors for named input, e.g. `filter(dt, x = 1)` (@mgirlich, #267).

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -16,7 +16,9 @@ step_mutate <- function(parent, new_vars = list(), nested = FALSE) {
 
 dt_call.dtplyr_step_mutate <- function(x, needs_copy = x$needs_copy) {
   # i is always empty because we never mutate a subset
-  if (!x$nested) {
+  if (is_empty(x$new_vars)) {
+    j <- quote(.SD)
+  } else if (!x$nested) {
     j <- call2(":=", !!!x$new_vars)
   } else {
     mutate_list <- mutate_nested_vars(x$new_vars)

--- a/R/step-subset-arrange.R
+++ b/R/step-subset-arrange.R
@@ -16,6 +16,10 @@
 #' dt %>% arrange(across(mpg:disp))
 arrange.dtplyr_step <- function(.data, ..., .by_group = FALSE) {
   dots <- capture_dots(.data, ..., .j = FALSE)
+  if (!is_empty(dots)) {
+    dots <- set_names(dots, NULL)
+  }
+
   if (.by_group) {
     dots <- c(syms(.data$groups), dots)
   }

--- a/R/step-subset-arrange.R
+++ b/R/step-subset-arrange.R
@@ -19,7 +19,6 @@ arrange.dtplyr_step <- function(.data, ..., .by_group = FALSE) {
   if (!is_empty(dots)) {
     dots <- set_names(dots, NULL)
   }
-
   if (.by_group) {
     dots <- c(syms(.data$groups), dots)
   }

--- a/R/step-subset-arrange.R
+++ b/R/step-subset-arrange.R
@@ -16,9 +16,6 @@
 #' dt %>% arrange(across(mpg:disp))
 arrange.dtplyr_step <- function(.data, ..., .by_group = FALSE) {
   dots <- capture_dots(.data, ..., .j = FALSE)
-  if (!is_empty(dots)) {
-    dots <- set_names(dots, NULL)
-  }
   if (.by_group) {
     dots <- c(syms(.data$groups), dots)
   }
@@ -28,6 +25,7 @@ arrange.dtplyr_step <- function(.data, ..., .by_group = FALSE) {
   }
 
   # Order without grouping then restore
+  dots <- set_names(dots, NULL)
   step <- step_subset(.data, i = call2("order", !!!dots), groups = character())
   step_group(step, groups = .data$groups)
 }

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -99,16 +99,16 @@ dt_squash_formula <- function(x, env, data, j = TRUE, replace = quote(!!.x)) {
 }
 
 across_names <- function(cols, funs, names = NULL, env = parent.frame()) {
-  n_times <- if (is_empty(funs)) 1 else length(funs)
-  if (n_times == 1) {
+  n_reps <- if (is_empty(funs)) 1 else length(funs)
+  if (n_reps == 1) {
     names <- names %||% "{.col}"
   } else {
     names <- names %||% "{.col}_{.fn}"
   }
 
   glue_env <- child_env(env,
-    .col = rep(cols, each = n_times),
-    .fn = rep(funs %||% seq_len(n_times), length(cols))
+    .col = rep(cols, each = n_reps),
+    .fn = rep(funs %||% seq_len(n_reps), length(cols))
   )
   glue::glue(names, .envir = glue_env)
 }

--- a/tests/testthat/test-step-subset-arrange.R
+++ b/tests/testthat/test-step-subset-arrange.R
@@ -28,7 +28,7 @@ test_that("can use with across", {
 
   expect_equal(
     dt %>% arrange(across(x:y)) %>% show_query(),
-    expr(DT[order(x, y)])
+    expr(DT[order(x = x, y = y)])
   )
 })
 

--- a/tests/testthat/test-step-subset-arrange.R
+++ b/tests/testthat/test-step-subset-arrange.R
@@ -28,7 +28,7 @@ test_that("can use with across", {
 
   expect_equal(
     dt %>% arrange(across(x:y)) %>% show_query(),
-    expr(DT[order(x = x, y = y)])
+    expr(DT[order(x, y)])
   )
 })
 

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -97,36 +97,42 @@ test_that("across() gives informative errors", {
 })
 
 test_that("across() can use named selections", {
-  df <- lazy_dt(data.frame(x = 1, y = 2))
+  dt <- lazy_dt(data.frame(x = 1, y = 2))
 
   # no fns
   expect_equal(
-    df %>% summarise(across(c(a = x, b = y))) %>% as.data.frame(),
-    data.frame(a = 1, b = 2)
+    capture_across(dt, across(c(a = x, b = y))),
+    list(a = quote(x), b = quote(y))
   )
   expect_equal(
-    df %>% summarise(across(all_of(c(a = "x", b = "y")))) %>% as.data.frame(),
-    data.frame(a = 1, b = 2)
+    capture_across(dt, across(all_of(c(a = "x", b = "y")))),
+    list(a = quote(x), b = quote(y))
   )
 
   # one fn
   expect_equal(
-    df %>% summarise(across(c(a = x, b = y), mean)) %>% as.data.frame(),
-    data.frame(a = 1, b = 2)
+    capture_across(dt, across(c(a = x, b = y), mean)),
+    list(a = quote(mean(x)), b = quote(mean(y)))
   )
   expect_equal(
-    df %>% summarise(across(all_of(c(a = "x", b = "y")), mean)) %>% as.data.frame(),
-    data.frame(a = 1, b = 2)
+    capture_across(dt, across(all_of(c(a = "x", b = "y")), mean)),
+    list(a = quote(mean(x)), b = quote(mean(y)))
   )
 
   # multiple fns
   expect_equal(
-    df %>% summarise(across(c(a = x, b = y), list(mean = mean, sum = sum))) %>% as.data.frame(),
-    data.frame(a_mean = 1, a_sum = 1, b_mean = 2, b_sum = 2)
+    capture_across(dt, across(c(a = x, b = y), list(mean, nm = sum))),
+    list(
+      a_mean = quote(mean(x)), a_nm = quote(sum(x)),
+      b_mean = quote(mean(y)), b_nm = quote(sum(y))
+    )
   )
   expect_equal(
-    df %>% summarise(across(all_of(c(a = "x", b = "y")), list(mean = mean, sum = sum))) %>% as.data.frame(),
-    data.frame(a_mean = 1, a_sum = 1, b_mean = 2, b_sum = 2)
+    capture_across(dt, across(all_of(c(a = "x", b = "y")), list(mean, nm = sum))),
+    list(
+      a_mean = quote(mean(x)), a_nm = quote(sum(x)),
+      b_mean = quote(mean(y)), b_nm = quote(sum(y))
+    )
   )
 
 })

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -3,7 +3,7 @@ test_that("across() translates NULL", {
 
   expect_equal(
     capture_across(dt, across(a:b)),
-    list(expr(a), expr(b))
+    list(a = expr(a), b = expr(b))
   )
 })
 
@@ -12,11 +12,11 @@ test_that("across() drops groups", {
 
   expect_equal(
     capture_across(group_by(dt, a), across(everything())),
-    list(expr(b))
+    list(b = expr(b))
   )
   expect_equal(
     capture_across(group_by(dt, b), across(everything())),
-    list(expr(a))
+    list(a = expr(a))
   )
 })
 
@@ -94,6 +94,50 @@ test_that("across() gives informative errors", {
     capture_across(dt, across(a, 1))
     capture_across(dt, across(a, list(1)))
   })
+})
+
+test_that("across() can use named selections", {
+  df <- lazy_dt(data.frame(x = 1, y = 2))
+
+  # no fns
+  expect_equal(
+    df %>% summarise(across(c(a = x, b = y))) %>% as.data.frame(),
+    data.frame(a = 1, b = 2)
+  )
+  expect_equal(
+    df %>% summarise(across(all_of(c(a = "x", b = "y")))) %>% as.data.frame(),
+    data.frame(a = 1, b = 2)
+  )
+
+  # one fn
+  expect_equal(
+    df %>% summarise(across(c(a = x, b = y), mean)) %>% as.data.frame(),
+    data.frame(a = 1, b = 2)
+  )
+  expect_equal(
+    df %>% summarise(across(all_of(c(a = "x", b = "y")), mean)) %>% as.data.frame(),
+    data.frame(a = 1, b = 2)
+  )
+
+  # multiple fns
+  expect_equal(
+    df %>% summarise(across(c(a = x, b = y), list(mean = mean, sum = sum))) %>% as.data.frame(),
+    data.frame(a_mean = 1, a_sum = 1, b_mean = 2, b_sum = 2)
+  )
+  expect_equal(
+    df %>% summarise(across(all_of(c(a = "x", b = "y")), list(mean = mean, sum = sum))) %>% as.data.frame(),
+    data.frame(a_mean = 1, a_sum = 1, b_mean = 2, b_sum = 2)
+  )
+
+})
+
+test_that("across() can handle empty selection", {
+  dt <- lazy_dt(data.table(x = 1, y = 2), "DT")
+
+  expect_equal(
+    dt %>% mutate(across(character(), c)) %>% show_query(),
+    expr(copy(DT)[, .SD])
+  )
 })
 
 


### PR DESCRIPTION
Should work the same as dplyr, as implemented in https://github.com/tidyverse/dplyr/pull/5889.

``` r
library(dplyr, warn.conflicts = FALSE)
library(dtplyr)

lazy_dt(data.frame(x = 1, y = 2)) %>% 
  summarise(across(c(z = y), ~ .^2))
#> Source: local data table [1 x 1]
#> Call:   `_DT1`[, .(z = y^2)]
#> 
#>       z
#>   <dbl>
#> 1     4
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```

<sup>Created on 2021-08-31 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Things to note:

- Allowing named selections makes empty selections possible, so the empty-selection case for mutate is also handled in this PR.
- The "non-expanded" cases tested in the dplyr PR don't work in either the current GitHub dtplyr or this PR.
