### PR TITLE
Avoid duplicated columns in `count`, `tally`, and `summarise`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # dtplyr (development version)
 
+* `tally()` and `count()` now follow the dplyr convention of creating a unique 
+  name if the default output `name` (n) already exists (@eutwt, #295).
+
+* Fixed a bug which prevented changing the value of a group variable with
+  `summarise()`, `tally()`, or `count()` (@eutwt, #295).
+
 * `if_any()` and `if_all()` now default to `.cols = everything()` when `.cols` 
   isn't provided (@eutwt, #294).
 

--- a/R/count.R
+++ b/R/count.R
@@ -68,7 +68,7 @@ check_name <- function(name, vars) {
         i = "Use `name = \"new_name\"` to pick a new name."
       ))
     }
-  } else if (!is.character(name) || length(name) != 1) {
+  } else if (!is_string(name)) {
     abort("`name` must be a single string.")
   }
 

--- a/R/count.R
+++ b/R/count.R
@@ -69,7 +69,7 @@ check_name <- function(name, vars) {
       ))
     }
   } else if (!is_string(name)) {
-    abort("`name` must be a single string.")
+    abort("`name` must be a string")
   }
 
   name

--- a/R/count.R
+++ b/R/count.R
@@ -39,12 +39,7 @@ tally.dtplyr_step <- function(.data, wt = NULL, sort = FALSE, name = NULL) {
   } else {
     n <- expr(sum(!!wt, na.rm = TRUE))
   }
-
-  if (is.null(name)) {
-    name <- "n"
-  } else if (!is_string(name)) {
-    abort("`name` must be a string")
-  }
+  name <- check_name(name, .data$groups)
 
   out <- summarise(.data, !!name := !!n)
 
@@ -60,3 +55,32 @@ tally.data.table <- function(.data, ...) {
   .data <- lazy_dt(.data)
   tally(.data, ...)
 }
+
+# Helpers -----------------------------------------------------------------
+
+check_name <- function(name, vars) {
+  if (is.null(name)) {
+    name <- n_name(vars)
+
+    if (name != "n") {
+      inform(c(
+        glue::glue("Storing counts in `{name}`, as `n` already present in input"),
+        i = "Use `name = \"new_name\"` to pick a new name."
+      ))
+    }
+  } else if (!is.character(name) || length(name) != 1) {
+    abort("`name` must be a single string.")
+  }
+
+  name
+}
+
+n_name <- function(x) {
+  name <- "n"
+  while (name %in% x) {
+    name <- paste0("n", name)
+  }
+
+  name
+}
+

--- a/R/step-subset-summarise.R
+++ b/R/step-subset-summarise.R
@@ -51,6 +51,15 @@ summarise.dtplyr_step <- function(.data, ..., .groups = NULL) {
     )
   }
 
+  replaced_group_vars <- intersect(.data$groups, names(dots))
+  if (!is_empty(replaced_group_vars)) {
+    out <- step_subset(
+      out,
+      groups = character(),
+      j = expr(!!replaced_group_vars := NULL)
+    )
+  }
+
   out_groups <- summarise_groups(.data, .groups, caller_env())
   step_group(out, groups = out_groups)
 }

--- a/tests/testthat/_snaps/step-call-pivot_wider.md
+++ b/tests/testthat/_snaps/step-call-pivot_wider.md
@@ -3,7 +3,7 @@
     Code
       show_query(step)
     Output
-      setnames(dcast(`_DT12`, formula = "..." ~ x + y, value.var = c("a", 
+      setnames(dcast(DT, formula = "..." ~ x + y, value.var = c("a", 
       "b"))[, .(a_X_1, a_Y_2, b_X_1, b_Y_2)], c("a_X_1", "a_Y_2", "b_X_1", 
       "b_Y_2"), c("X1_a", "Y2_a", "X1_b", "Y2_b"))
 

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -25,6 +25,19 @@ test_that("can control name", {
   )
 })
 
+test_that("name can match existing group var", {
+  dt <- data.table(a = 2)
+
+  expect_equal(
+    dt %>% group_by(a) %>% tally(name = 'a') %>% collect(),
+    tibble(a = 1)
+  )
+  expect_equal(
+    dt %>% count(a, name = 'a') %>% collect(),
+    tibble(a = 1)
+  )
+})
+
 
 test_that("can weight", {
   dt <- lazy_dt(data.table(x = c(1, 1, 2), y = c(1, 2, 10)), "DT")
@@ -48,4 +61,30 @@ test_that("tally works", {
     dt %>% group_by(x) %>% tally() %>% collect(),
     tibble(x = c(1, 2), n = c(3, 1))
   )
+})
+
+test_that("informs if n column already present, unless overridden", {
+  dt <- lazy_dt(data.frame(n = c(1, 1, 2, 2, 2)))
+  expect_message(out <- count(dt, n), "already present")
+  expect_named(as_tibble(out), c("n", "nn"))
+
+  # not a good idea, but supported
+  expect_message(out <- count(dt, n, name = "n"), NA)
+  expect_named(as_tibble(out), "n")
+
+  expect_message(out <- count(dt, n, name = "nn"), NA)
+  expect_named(as_tibble(out), c("n", "nn"))
+
+  dt <- lazy_dt(data.frame(n = c(1, 1, 2, 2, 2), nn = 1:5))
+  expect_message(out <- count(dt, n), "already present")
+  expect_named(as_tibble(out), c("n", "nn"))
+
+  expect_message(out <- count(dt, n, nn), "already present")
+  expect_named(as_tibble(out), c("n", "nn", "nnn"))
+})
+
+test_that("name must be string", {
+  dt <- lazy_dt(data.frame(x = c(1, 2)))
+  expect_error(count(dt, x, name = 1), "string")
+  expect_error(count(dt, x, name = letters), "string")
 })

--- a/tests/testthat/test-step-call-pivot_wider.R
+++ b/tests/testthat/test-step-call-pivot_wider.R
@@ -66,11 +66,14 @@ test_that("column with `...j` name can be used as `names_from`", {
 # column names -------------------------------------------------------------
 
 test_that("names_glue affects output names & auto-converts data.table to lazy_dt", {
-  df <- data.table(
-    x = c("X", "Y"),
-    y = 1:2,
-    a = 1:2,
-    b = 1:2
+  df <- lazy_dt(
+    data.frame(
+      x = c("X", "Y"),
+      y = 1:2,
+      a = 1:2,
+      b = 1:2
+    ),
+    "DT"
   )
 
   step <- pivot_wider(df, names_from = x:y, values_from = a:b, names_glue = "{x}{y}_{.value}")

--- a/tests/testthat/test-step-subset-summarise.R
+++ b/tests/testthat/test-step-subset-summarise.R
@@ -102,3 +102,21 @@ test_that("summarise(.groups=)", {
 
   expect_snapshot_error(df %>% summarise(.groups = "rowwise"))
 })
+
+test_that("can change group vars", {
+  dt <- lazy_dt(data.frame(a = 1), "DT") %>% group_by(a)
+
+  res <- dt %>% summarise(a = 2)
+  expect_equal(
+    show_query(res),
+    expr(DT[, .(a = 2), keyby = .(a)][, `:=`("a", NULL)])
+  )
+  expect_equal(
+    as_tibble(res), tibble(a = 2)
+  )
+
+  # but not with across
+  expect_error(
+    dt %>% summarise(across(a, ~ 2)), "Column `a` doesn't exist"
+  )
+})


### PR DESCRIPTION
This fixes the following errors (and instead produces results matching dplyr)

``` r
library(dtplyr)
library(dplyr, warn.conflicts = FALSE)
dt <- lazy_dt(data.frame(a = 2, n = 3))

dt %>% 
  count(a, name = 'a') %>% 
  as_tibble()
#> Error: Column name `a` must not be duplicated.
#> Use .name_repair to specify repair.

dt %>% 
  group_by(a) %>% 
  summarise(a = 1) %>% 
  as_tibble()
#> Error: Column name `a` must not be duplicated.
#> Use .name_repair to specify repair.

dt %>% 
  count(n) %>% 
  as_tibble()
#> Error: Column name `n` must not be duplicated.
#> Use .name_repair to specify repair.
```

<sup>Created on 2021-09-04 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>