### PR TITLE
Translate `semi_join` more directly using `mult = 'first'`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dtplyr (development version)
 
+* `semi_join()` is now translated as a single `[.data.table` call with `nomatch = NULL`
+  and `mult = 'first'` (@eutwt #296)
+
 * `if_any()` and `if_all()` now default to `.cols = everything()` when `.cols` 
   isn't provided (@eutwt, #294).
 

--- a/R/step-join.R
+++ b/R/step-join.R
@@ -78,7 +78,7 @@ dt_call.dtplyr_step_join <- function(x, needs_copy = x$needs_copy) {
     inner = call2("[", lhs, rhs, on = on, nomatch = NULL),
     right = call2("[", lhs, rhs, on = on, allow.cartesian = TRUE),
     anti = call2("[", lhs, call2("!", rhs), on = on),
-    semi = call2("[", lhs, rhs, on = on, nomatch = NULL, mult = 'first')
+    semi = call2("[", lhs, rhs, j = x$vars, on = on, nomatch = NULL, mult = 'first')
   )
 }
 
@@ -189,6 +189,7 @@ semi_join.dtplyr_step <- function(x, y, ..., by = NULL, copy = FALSE) {
 #' @export
 semi_join.data.table <- function(x, y, ...) {
   x <- lazy_dt(x)
+  y <- lazy_dt(y)
   semi_join(x, y, ...)
 }
 

--- a/R/step-join.R
+++ b/R/step-join.R
@@ -78,7 +78,7 @@ dt_call.dtplyr_step_join <- function(x, needs_copy = x$needs_copy) {
     inner = call2("[", lhs, rhs, on = on, nomatch = NULL),
     right = call2("[", lhs, rhs, on = on, allow.cartesian = TRUE),
     anti = call2("[", lhs, call2("!", rhs), on = on),
-    semi = call2("[", lhs, call2("unique", call2("[", lhs, rhs, which = TRUE, nomatch = NULL, on = on)))
+    semi = call2("[", lhs, rhs, on = on, nomatch = NULL, mult = 'first')
   )
 }
 

--- a/R/step-join.R
+++ b/R/step-join.R
@@ -88,12 +88,11 @@ dt_call.dtplyr_step_join <- function(x, needs_copy = x$needs_copy) {
 #'
 #' These are methods for the dplyr generics [left_join()], [right_join()],
 #' [inner_join()], [full_join()], [anti_join()], and [semi_join()]. Left, right,
-#' inner, and anti join are translated to the `[.data.table` equivalent,
+#' inner, anti and semi join are translated to the `[.data.table` equivalent,
 #' full joins to [data.table::merge.data.table()].
 #' Left, right, and full joins are in some cases followed by calls to
 #' [data.table::setcolorder()] and [data.table::setnames()] to ensure that column
 #' order and names match dplyr conventions.
-#' Semi-joins don't have a direct data.table equivalent.
 #'
 #' @param x,y A pair of [lazy_dt()]s.
 #' @inheritParams dplyr::left_join

--- a/tests/testthat/test-step-join.R
+++ b/tests/testthat/test-step-join.R
@@ -72,7 +72,7 @@ test_that("simple usage generates expected translation", {
 
   expect_equal(
     dt1 %>% semi_join(dt2, by = "x") %>% show_query(),
-    expr(dt1[dt2, on = .(x), nomatch = NULL, mult = "first"])
+    expr(dt1[dt2, j = !!c("x", "y", "a"), on = .(x), nomatch = NULL, mult = "first"])
   )
 })
 

--- a/tests/testthat/test-step-join.R
+++ b/tests/testthat/test-step-join.R
@@ -72,7 +72,7 @@ test_that("simple usage generates expected translation", {
 
   expect_equal(
     dt1 %>% semi_join(dt2, by = "x") %>% show_query(),
-    expr(dt1[unique(dt1[dt2, which = TRUE, nomatch = NULL, on = .(x)])])
+    expr(dt1[dt2, on = .(x), nomatch = NULL, mult = "first"])
   )
 })
 


### PR DESCRIPTION
This translates `semi_join` to data.table is more directly. Should be a little faster too.

``` r
library(rlang)
library(data.table, warn.conflicts = FALSE)

a <- data.table(V1 = sample(3e6))[, V2 := 1]
b <- data.table(V1 = c(-sample(1e3), sample(2e6)))[, V2 := 2]
# give b many cols to make sure pr doesn't copy rhs cols
b[, paste0('V',3:40) := as.list(3:40)]

curr <- function(lhs, rhs, by) {
  call <- call2("[", lhs, call2("unique", call2("[", lhs, rhs, which = TRUE, nomatch = NULL, on = by)))
  eval(call)
}

pr <- function(lhs, rhs, by) {
  vars_lhs <- names(lhs)
  call <- call2("[", lhs, rhs, j = vars_lhs, on = by, nomatch = NULL, mult = 'first')
  eval(call)
}

library(bench)
mark(
  curr(a, b, by = 'V1'),
  pr(a, b, by = 'V1')
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression                 min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>            <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 curr(a, b, by = "V1")    432ms    441ms      2.27     127MB     3.40
#> 2 pr(a, b, by = "V1")      338ms    342ms      2.92     111MB     0
```

<sup>Created on 2021-09-04 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>