### PR TITLE
`group_by(.data, NULL)` acts like `ungroup()`

### DIFF
--- a/R/step-group.R
+++ b/R/step-group.R
@@ -72,6 +72,7 @@ add_grouping_param <- function(call, step, arrange = step$arrange) {
 group_by.dtplyr_step <- function(.data, ..., .add = FALSE, add = deprecated(), arrange = TRUE) {
   dots <- capture_dots(.data, ...)
   dots <- exprs_auto_name(dots)
+  dots <- dots[!sapply(dots, is.null)]
 
   if (lifecycle::is_present(add)) {
     lifecycle::deprecate_warn(

--- a/R/step-group.R
+++ b/R/step-group.R
@@ -72,7 +72,7 @@ add_grouping_param <- function(call, step, arrange = step$arrange) {
 group_by.dtplyr_step <- function(.data, ..., .add = FALSE, add = deprecated(), arrange = TRUE) {
   dots <- capture_dots(.data, ...)
   dots <- exprs_auto_name(dots)
-  dots <- dots[!sapply(dots, is.null)]
+  dots <- dots[!vapply(dots, is.null, logical(1))]
 
   if (lifecycle::is_present(add)) {
     lifecycle::deprecate_warn(

--- a/tests/testthat/test-step-group.R
+++ b/tests/testthat/test-step-group.R
@@ -76,9 +76,10 @@ test_that("`key` switches between keyby= and by=", {
   )
 })
 
-test_that("emtpy group_by ungroups", {
+test_that("emtpy and NULL group_by ungroups", {
   dt <- lazy_dt(data.frame(x = 1)) %>% group_by(x)
   expect_equal(group_by(dt) %>% group_vars(), character())
+  expect_equal(group_by(dt, NULL) %>% group_vars(), character())
   expect_equal(group_by(dt, !!!list()) %>% group_vars(), character())
 })
 


### PR DESCRIPTION
When using `group_by` in a function, it may be useful to have `group_by(.data, NULL)` perform an ungroup, consistent with dplyr, so that users can just pass `NULL` to the function's group variable argument. 

In dev dtplyr, `group_by(across(NULL))` can be used to ungroup, but using `across` shouldn't be necessary.

Closes #311
Another relevant issue:
#309

Current dplyr and dev dtplyr:

```r
library(dtplyr)
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(a = 1)

df %>% 
  group_by(NULL)
#> # A tibble: 1 × 1
#>       a
#>   <dbl>
#> 1     1

lazy_dt(df) %>% 
  group_by(NULL)
#> Warning in `[.data.table`(copy(`_DT1`), , `:=`(`NULL` = NULL)): Column 'NULL'
#> does not exist to remove
#> Source: local data table [1 x 1]
#> Groups: NULL
#> Call:   copy(`_DT1`)[, `:=`(`NULL` = NULL)]
#> 
#>       a
#>   <dbl>
#> 1     1
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results

df %>% 
  group_by(a) %>% 
  group_by(NULL)
#> # A tibble: 1 × 1
#>       a
#>   <dbl>
#> 1     1

lazy_dt(df) %>% 
  group_by(a) %>% 
  group_by(NULL)
#> Error in `[.data.table`(copy(`_DT2`), , `:=`(`NULL` = NULL), by = .(a)): RHS of := is NULL during grouped assignment, but it's not possible to delete parts of a column.
```