### PR TITLE
pass environment to eval_select in across

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dtplyr (development version)
 
+ * When called within a function, `across()` can access variables in that 
+   function's execution environment.
+
 # dtplyr 1.2.0
 
 ## New authors

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # dtplyr (development version)
 
- * When called within a function, `across()` can access variables in that 
-   function's execution environment.
+ * The `.cols` argument of `across` is evaluated in the environment from which 
+   `across` was called
 
 # dtplyr 1.2.0
 

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -8,7 +8,7 @@ dt_squash_across <- function(call, env, data, j = j) {
 
   tbl <- simulate_vars(data, drop_groups = TRUE)
   .cols <- call$.cols %||% expr(everything())
-  locs <- tidyselect::eval_select(.cols, tbl)
+  locs <- tidyselect::eval_select(.cols, tbl, env = env)
   cols <- syms(names(tbl))[locs]
 
   funs <- across_funs(call$.fns, env, data, j = j)

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -160,6 +160,14 @@ test_that("across() can handle empty selection", {
   )
 })
 
+test_that("across() can access function environment", {
+  dt <- lazy_dt(data.frame(y = 1))
+  fun <- function(x) capture_across(dt, across(all_of(x)))
+  expect_equal(
+    fun("y"),
+    list(y = expr(y))
+  )
+})
 
 # if_all ------------------------------------------------------------------
 

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -160,7 +160,7 @@ test_that("across() can handle empty selection", {
   )
 })
 
-test_that("across() can access function environment", {
+test_that("across() .cols is evaluated in across()'s calling environment", {
   dt <- lazy_dt(data.frame(y = 1))
   fun <- function(x) capture_across(dt, across(all_of(x)))
   expect_equal(


### PR DESCRIPTION
closes #317 

Reprex after PR commits:

``` r
set.seed(1)
data <- data.frame(g = LETTERS[1:2], x = runif(2))
f <- function(x, g = NULL) {
    x |> 
        dplyr::group_by(dplyr::across(dplyr::all_of(g))) |> 
        dplyr::summarise(mean_x = mean(.data[["x"]]))
}
f(data)
#> # A tibble: 1 × 1
#>   mean_x
#>    <dbl>
#> 1  0.319

data |> 
    dtplyr::lazy_dt() |> 
    f()
#> Source: local data table [1 x 1]
#> Call:   `_DT1`[, .(mean_x = mean(x))]
#> 
#>   mean_x
#>    <dbl>
#> 1  0.319
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results

f(data, g = "g")
#> # A tibble: 2 × 2
#>   g     mean_x
#>   <chr>  <dbl>
#> 1 A      0.266
#> 2 B      0.372

data |> 
    dtplyr::lazy_dt() |> 
    f(g = "g")
#> Source: local data table [2 x 2]
#> Call:   `_DT2`[, .(mean_x = mean(x)), keyby = .(g)]
#> 
#>   g     mean_x
#>   <chr>  <dbl>
#> 1 A      0.266
#> 2 B      0.372
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```

<sup>Created on 2021-12-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>