### PR TITLE
Allow "temp" vars in mutate by adding var = NULL at end

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dtplyr (development version)
 
+ * When called within a function, `across()` can access variables in that 
+   function's execution environment.
+
 # dtplyr 1.2.0
 
 ## New authors

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # dtplyr (development version)
 
- * When called within a function, `across()` can access variables in that 
-   function's execution environment.
+ * The `.cols` argument of `across` is evaluated in the environment from which 
+   `across` was called
 
 # dtplyr 1.2.0
 

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -29,6 +29,9 @@ transmute.dtplyr_step <- function(.data, ...) {
     dots <- dots[!is_group_var]
   }
 
+  remove_vars <- get_remove_vars(dots)
+  if (!is_empty(remove_vars)) dots <- dots[-remove_vars]
+
   if (is_empty(dots)) {
     # grouping variables have been removed from `dots` so `select()` would
     # produce a message "Adding grouping vars".
@@ -37,12 +40,13 @@ transmute.dtplyr_step <- function(.data, ...) {
     return(select(.data, !!!group_vars(.data)))
   }
 
-  if (!nested) {
+  if (!nested & is_empty(remove_vars)) {
     j <- call2(".", !!!dots)
   } else {
-    j <- mutate_nested_vars(dots)$expr
+    j <- mutate_braces_expr(dots, remove_vars)$expr
   }
   vars <- union(group_vars(.data), names(dots))
+  vars <- setdiff(vars, names(remove_vars))
   step_subset_j(.data, vars = vars, j = j)
 }
 

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -8,7 +8,7 @@ dt_squash_across <- function(call, env, data, j = j) {
 
   tbl <- simulate_vars(data, drop_groups = TRUE)
   .cols <- call$.cols %||% expr(everything())
-  locs <- tidyselect::eval_select(.cols, tbl)
+  locs <- tidyselect::eval_select(.cols, tbl, env = env)
   cols <- syms(names(tbl))[locs]
 
   funs <- across_funs(call$.fns, env, data, j = j)

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -106,6 +106,18 @@ test_that("emtpy mutate returns input", {
   expect_equal(mutate(dt, !!!list()), dt)
 })
 
+test_that("can remove previously created var with var = NULL", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(
+    collect(mutate(dt, y = 2, z = y*2, y = NULL)),
+    tibble(x = 1, z = 4)
+  )
+  expect_equal(
+    mutate(dt, y = 2, z = y*2, y = NULL)$vars,
+    c("x", "z")
+  )
+})
+
 # .before and .after -----------------------------------------------------------
 
 test_that("can use .before and .after to control column position", {

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -81,3 +81,17 @@ test_that("only transmuting groups works", {
   expect_equal(transmute(dt, x) %>% collect(), dt %>% collect())
   expect_equal(transmute(dt, x)$vars, "x")
 })
+
+
+test_that("can remove previously created var with var = NULL", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(
+    collect(transmute(dt, y = 2, z = y*2, y = NULL)),
+    tibble(z = 4)
+  )
+  expect_equal(
+    transmute(dt, y = 2, z = y*2, y = NULL)$vars,
+    "z"
+  )
+})
+

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -160,6 +160,14 @@ test_that("across() can handle empty selection", {
   )
 })
 
+test_that("across() can access function environment", {
+  dt <- lazy_dt(data.frame(y = 1))
+  fun <- function(x) capture_across(dt, across(all_of(x)))
+  expect_equal(
+    fun("y"),
+    list(y = expr(y))
+  )
+})
 
 # if_all ------------------------------------------------------------------
 

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -160,7 +160,7 @@ test_that("across() can handle empty selection", {
   )
 })
 
-test_that("across() can access function environment", {
+test_that("across() .cols is evaluated in across()'s calling environment", {
   dt <- lazy_dt(data.frame(y = 1))
   fun <- function(x) capture_across(dt, across(all_of(x)))
   expect_equal(


### PR DESCRIPTION
This allows the user to create a new var in mutate, use it, then add `var = NULL` at the end to exclude it from the final output (as is possible in dplyr).

``` r
library(dplyr, warn.conflicts = FALSE)
library(dtplyr)
lazy_dt(data.frame(x = 1)) %>% 
  mutate(
    y = 2,
    z = y*2,
    y = NULL
  )
#> Source: local data table [1 x 2]
#> Call:   copy(`_DT1`)[, `:=`(c("z"), {
#>     y <- 2
#>     z <- y * 2
#>     .(z)
#> })]
#> 
#>       x     z
#>   <dbl> <dbl>
#> 1     1     4
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```

<sup>Created on 2021-12-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>