### PR TITLE
Allow "temp" vars in mutate by adding var = NULL at end

### DIFF
--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -125,7 +125,7 @@ nested_vars <- function(.data, dots, all_vars) {
 get_remove_vars <- function(dots){
   # Detect vars created and then set to NULL in same mutate
   n_used <- tapply(seq_along(dots), names(dots), length)
-  last_i <- tapply(seq_along(dots), names(dots), last)
+  last_i <- tapply(seq_along(dots), names(dots), function(x) x[[length(x)]])
   last_is_null <- vapply(dots[last_i], is.null, lgl(1))
   last_i[last_is_null & n_used > 1]
 }

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -18,9 +18,7 @@ step_mutate <- function(parent, new_vars = list(), remove_vars = integer(), nest
 
 dt_call.dtplyr_step_mutate <- function(x, needs_copy = x$needs_copy) {
   # i is always empty because we never mutate a subset
-  if (is_empty(x$new_vars)) {
-    j <- quote(.SD)
-  } else if (!x$nested & is_empty(x$remove_vars)) {
+  if (!x$nested & is_empty(x$remove_vars)) {
     j <- call2(":=", !!!x$new_vars)
   } else {
     mutate_list <- mutate_braces_expr(x$new_vars, x$remove_vars)
@@ -82,6 +80,9 @@ mutate.dtplyr_step <- function(.data, ...,
 
   remove_vars <- get_remove_vars(dots)
   if (!is_empty(remove_vars)) dots <- dots[-remove_vars]
+  if (is_empty(setdiff(names(dots), names(remove_vars)))) {
+    return(.data)
+  }
 
   nested <- nested_vars(.data, dots, .data$vars)
   out <- step_mutate(.data, dots, remove_vars, nested)

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -29,6 +29,9 @@ transmute.dtplyr_step <- function(.data, ...) {
     dots <- dots[!is_group_var]
   }
 
+  remove_vars <- get_remove_vars(dots)
+  if (!is_empty(remove_vars)) dots <- dots[-remove_vars]
+
   if (is_empty(dots)) {
     # grouping variables have been removed from `dots` so `select()` would
     # produce a message "Adding grouping vars".
@@ -37,12 +40,13 @@ transmute.dtplyr_step <- function(.data, ...) {
     return(select(.data, !!!group_vars(.data)))
   }
 
-  if (!nested) {
+  if (!nested & is_empty(remove_vars)) {
     j <- call2(".", !!!dots)
   } else {
-    j <- mutate_nested_vars(dots)$expr
+    j <- mutate_braces_expr(dots, remove_vars)$expr
   }
   vars <- union(group_vars(.data), names(dots))
+  vars <- setdiff(vars, names(remove_vars))
   step_subset_j(.data, vars = vars, j = j)
 }
 

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -116,6 +116,15 @@ test_that("can remove previously created var with var = NULL", {
     mutate(dt, y = 2, z = y*2, y = NULL)$vars,
     c("x", "z")
   )
+  # even when no other vars are added
+  expect_equal(
+    collect(mutate(dt, y = 2, y = NULL)),
+    tibble(x = 1)
+  )
+  expect_equal(
+    mutate(dt, y = 2, y = NULL)$vars,
+    "x"
+  )
 })
 
 # .before and .after -----------------------------------------------------------

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -106,6 +106,18 @@ test_that("emtpy mutate returns input", {
   expect_equal(mutate(dt, !!!list()), dt)
 })
 
+test_that("can remove previously created var with var = NULL", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(
+    collect(mutate(dt, y = 2, z = y*2, y = NULL)),
+    tibble(x = 1, z = 4)
+  )
+  expect_equal(
+    mutate(dt, y = 2, z = y*2, y = NULL)$vars,
+    c("x", "z")
+  )
+})
+
 # .before and .after -----------------------------------------------------------
 
 test_that("can use .before and .after to control column position", {

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -81,3 +81,17 @@ test_that("only transmuting groups works", {
   expect_equal(transmute(dt, x) %>% collect(), dt %>% collect())
   expect_equal(transmute(dt, x)$vars, "x")
 })
+
+
+test_that("can remove previously created var with var = NULL", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(
+    collect(transmute(dt, y = 2, z = y*2, y = NULL)),
+    tibble(z = 4)
+  )
+  expect_equal(
+    transmute(dt, y = 2, z = y*2, y = NULL)$vars,
+    "z"
+  )
+})
+

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -156,7 +156,7 @@ test_that("across() can handle empty selection", {
 
   expect_equal(
     dt %>% mutate(across(character(), c)) %>% show_query(),
-    expr(copy(DT)[, .SD])
+    expr(DT)
   )
 })
 


### PR DESCRIPTION
So that this works:

``` r
library(dplyr, warn.conflicts = FALSE)
library(dtplyr)
lazy_dt(data.frame(x = 1)) %>% 
  mutate(
    y = 2,
    z = y*2,
    y = NULL
  )
#> Source: local data table [1 x 2]
#> Call:   copy(`_DT1`)[, `:=`(c("z"), {
#>     y <- 2
#>     z <- y * 2
#>     .(z)
#> })]
#> 
#>       x     z
#>   <dbl> <dbl>
#> 1     1     4
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```

<sup>Created on 2021-12-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>