### PR TITLE
rework capture_dots to progressively track vars

### DIFF
--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -1,6 +1,6 @@
 step_mutate <- function(parent, new_vars = list(), use_braces = FALSE) {
   vars <- union(parent$vars, names(new_vars))
-  null_or_temp <- function(x) is_null(x) | is_temp_var(x)
+  null_or_temp <- function(x) is_temp_var(x) | (is_quosure(x) && quo_is_null(x))
   vars <- setdiff(vars, names(new_vars)[vapply(new_vars, null_or_temp, lgl(1))])
 
   new_step(
@@ -86,7 +86,7 @@ mutate.dtplyr_step <- function(.data, ...,
   }
 
   nested <- nested_vars(.data, dots, .data$vars)
-  repeated <- any(duplicated(names(dots)))
+  repeated <- anyDuplicated(names(dots))
   out <- step_mutate(.data, dots, use_braces = nested | repeated)
 
   .before <- enquo(.before)

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -93,7 +93,7 @@ mutate.dtplyr_step <- function(.data, ...,
   .after <- enquo(.after)
   if (!quo_is_null(.before) || !quo_is_null(.after)) {
     # Only change the order of new columns
-    new <- setdiff(names(dots), .data$vars)
+    new <- setdiff(out$vars, .data$vars)
     out <- relocate(out, !!new, .before = !!.before, .after = !!.after)
   }
 

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -73,10 +73,12 @@ mutate_nested_vars <- function(mutate_vars) {
 #'   mutate(x1 = x + 1, x2 = x1 + 1)
 mutate.dtplyr_step <- function(.data, ...,
                                .before = NULL, .after = NULL) {
-  dots <- capture_dots(.data, ...)
+  dots <- capture_new_vars(.data, ...)
   if (is_null(dots)) {
     return(.data)
   }
+  to_remove <- vapply(dots, is_zap, lgl(1))
+  dots <- dots[!to_remove]
 
   nested <- nested_vars(.data, dots, .data$vars)
   out <- step_mutate(.data, dots, nested)
@@ -89,7 +91,7 @@ mutate.dtplyr_step <- function(.data, ...,
     out <- relocate(out, !!new, .before = !!.before, .after = !!.after)
   }
 
-  out
+  remove_vars(out, names(to_remove)[to_remove])
 }
 
 #' @export

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -86,7 +86,7 @@ mutate.dtplyr_step <- function(.data, ...,
   }
 
   nested <- nested_vars(.data, dots, .data$vars)
-  repeated <- any(tapply(dots, names(dots), length) > 1)
+  repeated <- any(duplicated(names(dots)))
   out <- step_mutate(.data, dots, use_braces = nested | repeated)
 
   .before <- enquo(.before)

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -1,6 +1,6 @@
 step_mutate <- function(parent, new_vars = list(), use_braces = FALSE) {
   vars <- union(parent$vars, names(new_vars))
-  null_or_temp <- function(x) is_temp_var(x) | (is_quosure(x) && quo_is_null(x))
+  null_or_temp <- function(x) is_null(x) | is_temp_var(x)
   vars <- setdiff(vars, names(new_vars)[vapply(new_vars, null_or_temp, lgl(1))])
 
   new_step(

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -37,7 +37,7 @@ transmute.dtplyr_step <- function(.data, ...) {
   }
 
   nested <- nested_vars(.data, dots, .data$vars)
-  repeated <- any(duplicated(names(dots)))
+  repeated <- anyDuplicated(names(dots))
   if (!(nested | repeated)) {
     j <- call2(".", !!!dots)
     vars <- union(group_vars(.data), names(dots))

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -13,7 +13,9 @@
 #' dt <- lazy_dt(dplyr::starwars)
 #' dt %>% transmute(name, sh = paste0(species, "/", homeworld))
 transmute.dtplyr_step <- function(.data, ...) {
-  dots <- capture_dots(.data, ...)
+  dots <- capture_new_vars(.data, ...)
+  to_remove <- vapply(dots, is_zap, lgl(1))
+  dots <- dots[!to_remove]
   nested <- nested_vars(.data, dots, .data$vars)
 
   groups <- group_vars(.data)
@@ -43,7 +45,8 @@ transmute.dtplyr_step <- function(.data, ...) {
     j <- mutate_nested_vars(dots)$expr
   }
   vars <- union(group_vars(.data), names(dots))
-  step_subset_j(.data, vars = vars, j = j)
+  out <- step_subset_j(.data, vars = vars, j = j)
+  remove_vars(out, names(to_remove)[to_remove])
 }
 
 #' @export

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -37,7 +37,7 @@ transmute.dtplyr_step <- function(.data, ...) {
   }
 
   nested <- nested_vars(.data, dots, .data$vars)
-  repeated <- any(tapply(dots, names(dots), length) > 1)
+  repeated <- any(duplicated(names(dots)))
   if (!(nested | repeated)) {
     j <- call2(".", !!!dots)
     vars <- union(group_vars(.data), names(dots))

--- a/R/step-subset.R
+++ b/R/step-subset.R
@@ -129,16 +129,3 @@ dt_call.dtplyr_step_subset <- function(x, needs_copy = x$needs_copy) {
   }
   out
 }
-
-remove_vars <- function(.data, vars) {
-  if (is_empty(vars)) {
-    return(.data)
-  } 
-  group_vars <- .data$groups
-  out <- step_subset(
-    .data, groups = character(), j = expr(!!unique(vars) := NULL),
-    vars = setdiff(.data$vars, vars)
-  )
-  group_by(out, !!!syms(group_vars))
-}
-

--- a/R/step-subset.R
+++ b/R/step-subset.R
@@ -129,3 +129,14 @@ dt_call.dtplyr_step_subset <- function(x, needs_copy = x$needs_copy) {
   }
   out
 }
+
+remove_vars <- function(.data, vars) {
+  if (is_empty(vars)) {
+    return(.data)
+  } 
+  step_subset(
+    .data, groups = character(), j = expr(!!unique(vars) := NULL),
+    vars = setdiff(.data$vars, vars)
+  )
+}
+

--- a/R/step-subset.R
+++ b/R/step-subset.R
@@ -134,9 +134,11 @@ remove_vars <- function(.data, vars) {
   if (is_empty(vars)) {
     return(.data)
   } 
-  step_subset(
+  group_vars <- .data$groups
+  out <- step_subset(
     .data, groups = character(), j = expr(!!unique(vars) := NULL),
     vars = setdiff(.data$vars, vars)
   )
+  group_by(out, !!!syms(group_vars))
 }
 

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -49,7 +49,8 @@ capture_new_vars <- function(.data, ...) {
     } else {
       dots[[i]] <- dot
     }
-    .data$vars <- union(.data$vars, names(dots)[i])
+    new_vars <- names(dot) %||% names(dots)[i]
+    .data$vars <- union(.data$vars, new_vars)
   }
 
   # Remove names from any list elements

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -44,7 +44,11 @@ capture_new_vars <- function(.data, ...) {
   dots <- as.list(enquos(..., .named = TRUE))
   for (i in seq_along(dots)) {
     dot <- dt_squash(dots[[i]], data = .data) 
-    if (!is.null(dot)) dots[[i]] <- dot
+    if (!is.null(dot)) {
+      dots[[i]] <- dot
+    } else {
+      dots[i] <- list(NULL)
+    }
     .data$vars <- union(.data$vars, names(dots)[i])
   }
 
@@ -57,7 +61,7 @@ capture_new_vars <- function(.data, ...) {
   out <- unlist(dots, recursive = FALSE)
 
   # detect temp vars i.e. repeated vars where last is var = NULL
-  var_is_null <- vapply(out, identical, y = quo(NULL), lgl(1))
+  var_is_null <- vapply(out, is.null, lgl(1))
   if (any(var_is_null)) {
     is_repeated <- duplicated(names(out))
     is_last <- !duplicated(names(out), fromLast = TRUE)

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -41,7 +41,7 @@ capture_dots <- function(.data, ..., .j = TRUE) {
 }
 
 capture_new_vars <- function(.data, ...) {
-  dots <- enquos(..., .named = TRUE)
+  dots <- as.list(enquos(..., .named = TRUE))
   for (i in seq_along(dots)) {
     dot <- dt_squash(dots[[i]], data = .data) 
     dots[[i]] <- dot %||% structure('zap', class = 'rlang_zap')

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -43,8 +43,8 @@ capture_dots <- function(.data, ..., .j = TRUE) {
 capture_new_vars <- function(.data, ...) {
   dots <- enquos(..., .named = TRUE)
   for (i in seq_along(dots)) {
-    dot <- dt_squash(dots[[i]], data = .data) %||% structure('zap', class = 'rlang_zap')
-    dots[[i]] <- dot
+    dot <- dt_squash(dots[[i]], data = .data) 
+    dots[[i]] <- dot %||% structure('zap', class = 'rlang_zap')
     .data$vars <- union(.data$vars, names(dots)[i])
   }
 

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -59,8 +59,9 @@ capture_new_vars <- function(.data, ...) {
   # detect temp vars i.e. repeated vars where last is var = NULL
   var_is_null <- vapply(out, identical, y = quo(NULL), lgl(1))
   if (any(var_is_null)) {
-    var_is_last <- rev(data.table::rowid(rev(names(out))) == 1)
-    temp_var_removal <- var_is_null & var_is_last
+    is_repeated <- duplicated(names(out))
+    is_last <- !duplicated(names(out), fromLast = TRUE)
+    temp_var_removal <- var_is_null & is_repeated & is_last
     for (i in seq_along(out)) {
       if (temp_var_removal[i]) {
         out[[i]] <- structure(list(), class = 'dtplyr_temp_var_removal')

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -40,6 +40,23 @@ capture_dots <- function(.data, ..., .j = TRUE) {
   unlist(dots, recursive = FALSE)
 }
 
+capture_new_vars <- function(.data, ...) {
+  dots <- enquos(..., .named = TRUE)
+  for (i in seq_along(dots)) {
+    dot <- dt_squash(dots[[i]], data = .data) %||% structure('zap', class = 'rlang_zap')
+    dots[[i]] <- dot
+    .data$vars <- union(.data$vars, names(dots)[i])
+  }
+
+  # Remove names from any list elements
+  is_list <- vapply(dots, is.list, logical(1))
+  names(dots)[is_list] <- ""
+
+  # Auto-splice list results from dt_squash()
+  dots[!is_list] <- lapply(dots[!is_list], list)
+  unlist(dots, recursive = FALSE)
+}
+
 capture_dot <- function(.data, x, j = TRUE) {
   dt_squash(enquo(x), data = .data, j = j)
 }

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -44,10 +44,10 @@ capture_new_vars <- function(.data, ...) {
   dots <- as.list(enquos(..., .named = TRUE))
   for (i in seq_along(dots)) {
     dot <- dt_squash(dots[[i]], data = .data) 
-    if (!is.null(dot)) {
-      dots[[i]] <- dot
-    } else {
+    if (is.null(dot)) {
       dots[i] <- list(NULL)
+    } else {
+      dots[[i]] <- dot
     }
     .data$vars <- union(.data$vars, names(dots)[i])
   }

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -135,6 +135,14 @@ test_that("across() can access previously created variables", {
   )
 })
 
+test_that("can have repeated non-nested variables", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(
+    collect(mutate(dt, y = 2, y = 3)),
+    tibble(x = 1, y = 3)
+  )
+})
+
 test_that("new columns take precedence over global variables", {
   dt <- lazy_dt(data.frame(x = 1))
   y <- 'global var'

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -106,6 +106,44 @@ test_that("emtpy mutate returns input", {
   expect_equal(mutate(dt, !!!list()), dt)
 })
 
+test_that("can remove previously created var with var = NULL", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(
+    collect(mutate(dt, y = 2, z = y*2, y = NULL)),
+    tibble(x = 1, z = 4)
+  )
+  expect_equal(
+    mutate(dt, y = 2, z = y*2, y = NULL)$vars,
+    c("x", "z")
+  )
+  # even when no other vars are added
+  expect_equal(
+    collect(mutate(dt, y = 2, y = NULL)),
+    tibble(x = 1)
+  )
+  expect_equal(
+    mutate(dt, y = 2, y = NULL)$vars,
+    "x"
+  )
+})
+
+test_that("across() can access previously created variables", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(
+    collect(mutate(dt, y = 2, across(y, sqrt))),
+    tibble(x = 1, y = sqrt(2))
+  )
+})
+
+test_that("new columns take precedence over global variables", {
+  dt <- lazy_dt(data.frame(x = 1))
+  y <- 'global var'
+  expect_equal(
+    collect(mutate(dt, y = 2, z = y + 1)),
+    tibble(x = 1, y = 2, z = 3)
+  )
+})
+
 # .before and .after -----------------------------------------------------------
 
 test_that("can use .before and .after to control column position", {

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -92,6 +92,15 @@ test_that("can remove previously created var with var = NULL", {
     transmute(dt, y = 2, z = y*2, y = NULL)$vars,
     "z"
   )
+  # even when no other vars are added
+  expect_equal(
+    collect(transmute(dt, y = 2, y = NULL)),
+    tibble()
+  )
+  expect_equal(
+    transmute(dt, y = 2, y = NULL)$vars,
+    character()
+  )
 })
 
 test_that("across() can access previously created variables", {

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -102,6 +102,14 @@ test_that("across() can access previously created variables", {
   )
 })
 
+test_that("can have repeated non-nested variables", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(
+    collect(transmute(dt, y = 2, y = 3)),
+    tibble(y = 3)
+  )
+})
+
 test_that("new columns take precedence over global variables", {
   dt <- lazy_dt(data.frame(x = 1))
   y <- 'global var'
@@ -110,4 +118,3 @@ test_that("new columns take precedence over global variables", {
     tibble(y = 2, z = 3)
   )
 })
-

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -81,3 +81,33 @@ test_that("only transmuting groups works", {
   expect_equal(transmute(dt, x) %>% collect(), dt %>% collect())
   expect_equal(transmute(dt, x)$vars, "x")
 })
+
+test_that("can remove previously created var with var = NULL", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(
+    collect(transmute(dt, y = 2, z = y*2, y = NULL)),
+    tibble(z = 4)
+  )
+  expect_equal(
+    transmute(dt, y = 2, z = y*2, y = NULL)$vars,
+    "z"
+  )
+})
+
+test_that("across() can access previously created variables", {
+  dt <- lazy_dt(data.frame(x = 1))
+  expect_equal(
+    collect(transmute(dt, y = 2, across(y, sqrt))),
+    tibble(y = sqrt(2))
+  )
+})
+
+test_that("new columns take precedence over global variables", {
+  dt <- lazy_dt(data.frame(x = 1))
+  y <- 'global var'
+  expect_equal(
+    collect(transmute(dt, y = 2, z = y + 1)),
+    tibble(y = 2, z = 3)
+  )
+})
+


### PR DESCRIPTION
closes #321
closes #281
closes #320

Because `capture_dots` in `mutate.dtplyr_step` does not keep track of new variables as they are created, the four actions below result in an error on the main branch. This PR also fixes the analogous actions for `transmute`

``` r
library(dplyr, warn.conflicts = FALSE)
library(dtplyr)

dt <- lazy_dt(data.frame(x = 1))
mutate(dt, y = 2, z = y*2, y = NULL)
#> Source: local data table [1 x 2]
#> Call:   copy(`_DT1`)[, `:=`(c("z"), {
#>     y <- 2
#>     z <- y * 2
#>     .(z)
#> })]
#> 
#>       x     z
#>   <dbl> <dbl>
#> 1     1     4
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
mutate(dt, y = 2, across(y, sqrt))
#> Source: local data table [1 x 2]
#> Call:   copy(`_DT1`)[, `:=`(c("y"), {
#>     y <- 2
#>     y <- sqrt(y)
#>     .(y)
#> })]
#> 
#>       x     y
#>   <dbl> <dbl>
#> 1     1  1.41
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
mutate(dt, y = 2, y = 3)
#> Source: local data table [1 x 2]
#> Call:   copy(`_DT1`)[, `:=`(c("y"), {
#>     y <- 2
#>     y <- 3
#>     .(y)
#> })]
#> 
#>       x     y
#>   <dbl> <dbl>
#> 1     1     3
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
y <- 'global var'
mutate(dt, y = 2, z = y + 1)
#> Source: local data table [1 x 3]
#> Call:   copy(`_DT1`)[, `:=`(c("y", "z"), {
#>     y <- 2
#>     z <- y + 1
#>     .(y, z)
#> })]
#> 
#>       x     y     z
#>   <dbl> <dbl> <dbl>
#> 1     1     2     3
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```

<sup>Created on 2021-12-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>