### PR TITLE
mutate edge cases

### DIFF
--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -76,6 +76,8 @@ mutate_with_braces <- function(mutate_vars) {
 mutate.dtplyr_step <- function(.data, ...,
                                .before = NULL, .after = NULL) {
   dots <- capture_new_vars(.data, ...)
+  trivial_dot <- imap(dots, ~ is_symbol(.x) && sym(.y) == .x && .y %in% .data$vars)
+  dots <- dots[!as.vector(trivial_dot, "logical")]
   dots_list <- process_new_vars(.data, dots)
   dots <- dots_list$dots
   if (is_null(dots) || is_empty(dots)) {

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -35,7 +35,7 @@ dt_call.dtplyr_step_mutate <- function(x, needs_copy = x$needs_copy) {
 }
 
 mutate_with_braces <- function(mutate_vars) {
-  # var removals with var = NULL don't work well with expressions using braces
+  # removing vars with var = NULL doesn't work well with expressions using braces
   # need to identify those cases to deal with them in a separate step
   var_is_null <- vapply(mutate_vars, is.null, lgl(1))
   is_last <- !duplicated(names(mutate_vars), fromLast = TRUE)

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -1,6 +1,8 @@
 step_mutate <- function(parent, new_vars = list(), use_braces = FALSE) {
   vars <- union(parent$vars, names(new_vars))
-  vars <- setdiff(vars, names(new_vars)[vapply(new_vars, is_null, lgl(1))])
+  var_is_null <- vapply(new_vars, is_null, lgl(1)) 
+  is_last <- !duplicated(names(new_vars), fromLast = TRUE)
+  vars <- setdiff(vars, names(new_vars)[var_is_null & is_last])
 
   new_step(
     parent,

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -83,7 +83,7 @@ mutate.dtplyr_step <- function(.data, ...,
   nested <- nested_vars(.data, dots, .data$vars)
   repeated <- anyDuplicated(names(dots))
   use_braces <- nested | repeated
-  grouped_data <- !is_empty(.data$groups)
+  grouped_data <- !is_empty(group_vars(.data))
   need_removal_step <- any(var_removals) && (use_braces | grouped_data)
   if (need_removal_step) {
     dots <- dots[!var_removals]

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -78,7 +78,7 @@ mutate.dtplyr_step <- function(.data, ...,
   dots <- capture_new_vars(.data, ...)
   dots_list <- process_new_vars(.data, dots)
   dots <- dots_list$dots
-  if (is_null(dots) | is_empty(dots)) {
+  if (is_null(dots) || is_empty(dots)) {
     return(.data)
   }
 

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -80,9 +80,9 @@ mutate.dtplyr_step <- function(.data, ...,
 
   var_removals <- vapply(dots, is_var_removal, logical(1))
   vars_removed <- names(var_removals)[var_removals]
-  nested_vars <- nested_vars(.data, dots, .data$vars)
-  repeated_vars <- anyDuplicated(names(dots))
-  use_braces <- nested_vars | repeated_vars
+  nested <- nested_vars(.data, dots, .data$vars)
+  repeated <- anyDuplicated(names(dots))
+  use_braces <- nested | repeated
   grouped_data <- !is_empty(.data$groups)
   need_removal_step <- any(var_removals) && (use_braces | grouped_data)
   if (need_removal_step) {

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -74,7 +74,7 @@ mutate_with_braces <- function(mutate_vars) {
 mutate.dtplyr_step <- function(.data, ...,
                                .before = NULL, .after = NULL) {
   dots <- capture_new_vars(.data, ...)
-  if (is_empty(dots)) {
+  if (is_null(dots) | is_empty(dots)) {
     return(.data)
   }
 

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -14,19 +14,35 @@
 #' dt %>% transmute(name, sh = paste0(species, "/", homeworld))
 transmute.dtplyr_step <- function(.data, ...) {
   dots <- capture_new_vars(.data, ...)
-  use_braces <- nested_vars(.data, dots, .data$vars) | anyDuplicated(names(dots))
 
+  var_removals <- vapply(dots, is_var_removal, logical(1))
+  vars_removed <- names(var_removals)[var_removals]
+  nested_vars <- nested_vars(.data, dots, .data$vars)
+  repeated_vars <- anyDuplicated(names(dots))
+  use_braces <- nested_vars | repeated_vars
   groups <- group_vars(.data)
-  if (!is_empty(groups)) {
+  grouped_data <- !is_empty(groups)
+  need_removal_step <- any(var_removals) && (use_braces | grouped_data)
+
+  if (need_removal_step) {
+    dots <- dots[!var_removals]
+  } else {
+    dots <- unmark_var_removals(dots, var_removals)  
+  }
+
+  if (grouped_data) {
     # TODO could check if there is actually anything mutated, e.g. to avoid
     # DT[, .(x = x)]
     is_group_var <- names(dots) %in% groups
-    group_dots <- dots[is_group_var]
 
-    .data <- mutate(ungroup(.data), !!!group_dots)
-    .data <- group_by(.data, !!!syms(groups))
+    if (any(is_group_var)) {
+      group_dots <- dots[is_group_var]
 
-    dots <- dots[!is_group_var]
+      .data <- mutate(ungroup(.data), !!!group_dots)
+      .data <- group_by(.data, !!!syms(groups))
+
+      dots <- dots[!is_group_var]
+    }
   }
 
   if (is_empty(dots)) {
@@ -46,8 +62,8 @@ transmute.dtplyr_step <- function(.data, ...) {
   vars <- union(group_vars(.data), names(dots))
   out <- step_subset_j(.data, vars = vars, j = j)
 
-  if (use_braces) {
-    out <- remove_vars(out, mutate_list$removed_vars)
+  if (need_removal_step) {
+    out <- remove_vars(out, vars_removed)
   }
 
   out

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -53,7 +53,7 @@ transmute.dtplyr_step <- function(.data, ...) {
   if (!use_braces) {
     j <- call2(".", !!!dots)
   } else {
-    j <- mutate_nested_vars(dots)$expr
+    j <- mutate_with_braces(dots)$expr
   }
   vars <- union(group_vars(.data), names(dots))
   out <- step_subset_j(.data, vars = vars, j = j)

--- a/R/step-subset-transmute.R
+++ b/R/step-subset-transmute.R
@@ -14,12 +14,12 @@
 #' dt %>% transmute(name, sh = paste0(species, "/", homeworld))
 transmute.dtplyr_step <- function(.data, ...) {
   dots <- capture_new_vars(.data, ...)
+  nested <- nested_vars(.data, dots, .data$vars)
 
   var_removals <- vapply(dots, is_var_removal, logical(1))
   vars_removed <- names(var_removals)[var_removals]
-  nested_vars <- nested_vars(.data, dots, .data$vars)
-  repeated_vars <- anyDuplicated(names(dots))
-  use_braces <- nested_vars | repeated_vars
+  repeated <- anyDuplicated(names(dots))
+  use_braces <- nested | repeated
   groups <- group_vars(.data)
   grouped_data <- !is_empty(groups)
   need_removal_step <- any(var_removals) && (use_braces | grouped_data)

--- a/R/step-subset.R
+++ b/R/step-subset.R
@@ -129,3 +129,15 @@ dt_call.dtplyr_step_subset <- function(x, needs_copy = x$needs_copy) {
   }
   out
 }
+
+remove_vars <- function(.data, vars) {
+  if (is_empty(vars)) {
+    return(.data)
+  } 
+  out <- step_subset(
+    .data, groups = character(), j = expr(!!unique(vars) := NULL),
+    vars = setdiff(.data$vars, vars)
+  )
+  group_by(out, !!!syms(.data$groups))
+}
+

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -40,6 +40,27 @@ capture_dots <- function(.data, ..., .j = TRUE) {
   unlist(dots, recursive = FALSE)
 }
 
+capture_new_vars <- function(.data, ...) {
+  dots <- as.list(enquos(..., .named = TRUE))
+  for (i in seq_along(dots)) {
+    dot <- dt_squash(dots[[i]], data = .data)
+    if (is.null(dot)) {
+      dots[i] <- list(NULL)
+    } else {
+      dots[[i]] <- dot
+    }
+    .data$vars <- union(.data$vars, names(dots)[i])
+  }
+
+  # Remove names from any list elements
+  is_list <- vapply(dots, is.list, logical(1))
+  names(dots)[is_list] <- ""
+
+  # Auto-splice list results from dt_squash()
+  dots[!is_list] <- lapply(dots[!is_list], list)
+  unlist(dots, recursive = FALSE)
+}
+
 capture_dot <- function(.data, x, j = TRUE) {
   dt_squash(enquo(x), data = .data, j = j)
 }

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -58,19 +58,7 @@ capture_new_vars <- function(.data, ...) {
 
   # Auto-splice list results from dt_squash()
   dots[!is_list] <- lapply(dots[!is_list], list)
-  out <- unlist(dots, recursive = FALSE)
-
-  # identify & mark when var = NULL is being used to remove a variable
-  var_is_null <- vapply(out, is.null, logical(1))
-  is_last <- !duplicated(names(out), fromLast = TRUE)
-  is_var_removal <- var_is_null & is_last
-  map2(out, is_var_removal, function(dot, is_rm) {
-    if (is_rm) {
-      structure(list(), class = 'var_removal')
-    } else {
-      dot
-    }
-  })
+  unlist(dots, recursive = FALSE)
 }
 
 capture_dot <- function(.data, x, j = TRUE) {

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -49,7 +49,7 @@ capture_new_vars <- function(.data, ...) {
     } else {
       dots[[i]] <- dot
     }
-    .data$vars <- union(.data$vars, names(dots)[i])
+    .data$vars <- union(.data$vars, names(dot) %||% names(dots)[i])
   }
 
   # Remove names from any list elements

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -58,7 +58,19 @@ capture_new_vars <- function(.data, ...) {
 
   # Auto-splice list results from dt_squash()
   dots[!is_list] <- lapply(dots[!is_list], list)
-  unlist(dots, recursive = FALSE)
+  out <- unlist(dots, recursive = FALSE)
+
+  # identify & mark when var = NULL is being used to remove a variable
+  var_is_null <- vapply(out, is.null, logical(1))
+  is_last <- !duplicated(names(out), fromLast = TRUE)
+  is_var_removal <- var_is_null & is_last
+  map2(out, is_var_removal, function(dot, is_rm) {
+    if (is_rm) {
+      structure(list(), class = 'var_removal')
+    } else {
+      dot
+    }
+  })
 }
 
 capture_dot <- function(.data, x, j = TRUE) {

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -138,6 +138,12 @@ test_that("emtpy mutate returns input", {
   expect_equal(mutate(dt, !!!list()), dt)
 })
 
+test_that("unnamed arguments matching column names are ignored", {
+  dt <- lazy_dt(data.frame(x = 1), "DT")
+  expect_identical(mutate(dt, x), dt)
+  expect_snapshot(mutate(dt, y), error = TRUE)
+})
+
 test_that("new columns take precedence over global variables", {
   dt <- lazy_dt(data.frame(x = 1), "DT")
   y <- 'global var'

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -142,6 +142,31 @@ test_that("var = NULL works when var is not in original data", {
   )
 })
 
+test_that("var = NULL works when data is grouped", {
+  # when var is not in original data
+  dt <- lazy_dt(data.frame(x = 1, g = 1)) %>% group_by(g)
+  step <- mutate(dt, y = 2, z = y*2, y = NULL)
+  expect_equal(
+    collect(step),
+    tibble(x = 1, g = 1, z = 4) %>% group_by(g)
+  )
+  expect_equal(
+    step$vars,
+    c("x", "g", "z")
+  )
+  # when var is in original data
+  dt <- lazy_dt(data.frame(x = 1, g = 1)) %>% group_by(g)
+  step <-  dt %>% mutate(x = 2, z = x*2, x = NULL)
+  expect_equal(
+    collect(step),
+    tibble(g = 1, z = 4) %>% group_by(g)
+  )
+  expect_equal(
+    step$vars,
+    c("g", "z")
+  )
+})
+
 test_that("across() can access previously created variables", {
   dt <- lazy_dt(data.frame(x = 1))
   step <- mutate(dt, y = 2, across(y, sqrt))

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -84,7 +84,7 @@ test_that("only transmuting groups works", {
 
 test_that("var = NULL works when var is in original data", {
   dt <- lazy_dt(data.frame(x = 1))
-  step <-  dt %>% mutate(x = 2, z = x*2, x = NULL)
+  step <- dt %>% transmute(x = 2, z = x*2, x = NULL)
   expect_equal(
     collect(step),
     tibble(z = 4)
@@ -115,6 +115,31 @@ test_that("var = NULL works when var is not in original data", {
   expect_equal(
     step$vars,
     character()
+  )
+})
+
+test_that("var = NULL works when data is grouped", {
+  # when var is in original data
+  dt <- lazy_dt(data.frame(x = 1, g = 1)) %>% group_by(g)
+  step <- dt %>% transmute(x = 2, z = x*2, x = NULL)
+  expect_equal(
+    collect(step),
+    tibble(g = 1, z = 4) %>% group_by(g)
+  )
+  expect_equal(
+    step$vars,
+    c("g", "z")
+  )
+  # when var is not in original data
+  dt <- lazy_dt(data.frame(x = 1, g = 1)) %>% group_by(g)
+  step <- transmute(dt, y = 2, z = y*2, y = NULL)
+  expect_equal(
+    collect(step),
+    tibble(g = 1, z = 4) %>% group_by(g)
+  )
+  expect_equal(
+    step$vars,
+    c("g", "z")
   )
 })
 

--- a/tests/testthat/test-step-subset-transmute.R
+++ b/tests/testthat/test-step-subset-transmute.R
@@ -81,3 +81,74 @@ test_that("only transmuting groups works", {
   expect_equal(transmute(dt, x) %>% collect(), dt %>% collect())
   expect_equal(transmute(dt, x)$vars, "x")
 })
+
+test_that("var = NULL works when var is in original data", {
+  dt <- lazy_dt(data.frame(x = 1))
+  step <-  dt %>% mutate(x = 2, z = x*2, x = NULL)
+  expect_equal(
+    collect(step),
+    tibble(z = 4)
+  )
+  expect_equal(
+    step$vars,
+    "z"
+  )
+})
+
+test_that("var = NULL works when var is not in original data", {
+  dt <- lazy_dt(data.frame(x = 1))
+  step <- transmute(dt, y = 2, z = y*2, y = NULL)
+  expect_equal(
+    collect(step),
+    tibble(z = 4)
+  )
+  expect_equal(
+    step$vars,
+    "z"
+  )
+  # when no other vars are added
+  step <- transmute(dt, y = 2, y = NULL)
+  expect_equal(
+    collect(step),
+    tibble()
+  )
+  expect_equal(
+    step$vars,
+    character()
+  )
+})
+
+test_that("across() can access previously created variables", {
+  dt <- lazy_dt(data.frame(x = 1))
+  step <- transmute(dt, y = 2, across(y, sqrt))
+  expect_equal(
+    collect(step),
+    tibble(y = sqrt(2))
+  )
+})
+
+test_that("can repeat named arguments", {
+  dt <- lazy_dt(data.frame(x = 1))
+  step <- transmute(dt, y = 2, y = 3)
+  expect_equal(
+    collect(step),
+    tibble(y = 3)
+  )
+  # even when first is NULL
+  step <- transmute(dt, y = NULL, y = 3)
+  expect_equal(
+    collect(step),
+    tibble(y = 3)
+  )
+})
+
+test_that("new columns take precedence over global variables", {
+  y <- 'global var'
+  dt <- lazy_dt(data.frame(x = 1))
+  step <- transmute(dt, y = 2, z = y + 1)
+  expect_equal(
+    collect(step),
+    tibble(y = 2, z = 3)
+  )
+})
+

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -156,7 +156,7 @@ test_that("across() can handle empty selection", {
 
   expect_equal(
     dt %>% mutate(across(character(), c)) %>% show_query(),
-    expr(copy(DT)[, .SD])
+    expr(DT)
   )
 })
 


### PR DESCRIPTION
closes #321
closes #281

All the tests added to test-step-mutate.R result in an error on the main branch. These are all pretty rare use-cases, but trying to make dtplyr as compatible with existing working dplyr code as possible, even if it's a bit odd.

The changes are:

- Solved by `process_new_vars`
  - If there are **repeated variable names**, e.g. `mutate(dt, z = 2, z = 3)` this needs to be handled the same way nested arguments are handled on the main branch (even if there is no nesting) to avoid an error. `mutate_nested_vars` is renamed to `mutate_with_braces` because it's= now not only used when arguments are nested.
    - [test](https://github.com/tidyverse/dtplyr/pull/324/files#diff-68dfa5e2cb0290c32457805c202b1e388a6823e6dabaeacaa3f9f4fd13f4ef13R73)
  - If there is a **variable removal**, i.e. a mutate argument `var = NULL` not followed by any other mutate arguments named `var` (e.g. not `var = NULL, var = 3`), then that variable should not be in the final output.
    - If the data is grouped, you need an additional step (`[.data.table` call) to remove the variable because `DT[, var := NULL, by = g]` results in an error.
    - If we are in a `mutate_with_braces` branch, it's hard to determine how you should modify the current `j` expression to get the correct output. Some things that seem like they should work don't, see example below. So to keep things simple, this case is handled the same as grouped data, i.e. an extra `[.data.table` call is added.
    - [test](https://github.com/tidyverse/dtplyr/pull/324/files#diff-68dfa5e2cb0290c32457805c202b1e388a6823e6dabaeacaa3f9f4fd13f4ef13R159)
 
 ```{r}
library(data.table)

dd <- data.table(x = 1)
dd[, c('z', 'x') := {x <- NULL; list(2, NULL)}][]
#>        x     z
#>    <num> <num>
#> 1:     2     2
```

<sup>Created on 2021-12-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

- Solved by `capture_new_vars`
  - The arguments need to be captured sequentially, so that the list of previously created variables is accessible at each capture. This fixes an issue with conflicting global variables and not being able to access previously created variables in mutate. 
    - [test](https://github.com/tidyverse/dtplyr/pull/324/files#diff-68dfa5e2cb0290c32457805c202b1e388a6823e6dabaeacaa3f9f4fd13f4ef13R120)