### PR TITLE
Do not translate namespaced calls

### DIFF
--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -104,10 +104,10 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     } else if (is_symbol(x[[2]], ".env")) {
       sym(paste0("..", var))
     }
-  } else if (is_call(x, c("coalesce", "replace_na"))) {
+  } else if (is_call(x, c("coalesce", "replace_na"), ns = '')) {
     args <- lapply(x[-1], dt_squash, env = env, data = data, j = j)
     call2("fcoalesce", !!!args)
-  } else if (is_call(x, "case_when")) {
+  } else if (is_call(x, "case_when", ns = '')) {
     # case_when(x ~ y) -> fcase(x, y)
     args <- unlist(lapply(x[-1], function(x) {
       list(
@@ -136,7 +136,7 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x[[1]] <- sym("-")
     x[[2]] <- get_expr(x[[2]])
     x
-  } else if (is_call(x, c("if_else", "ifelse"))) {
+  } else if (is_call(x, c("if_else", "ifelse"), ns = '')) {
     if (is_call(x, "if_else")) {
       x <- unname(match.call(dplyr::if_else, x))
     } else {
@@ -146,7 +146,7 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x[[1]] <- quote(fifelse)
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)
     x
-  } else if (is_call(x, c("lag", "lead"))) {
+  } else if (is_call(x, c("lag", "lead"), ns = '')) {
     if (is_call(x, "lag")) {
       type <- "lag"
       call <- match.call(dplyr::lag, x)

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -69,6 +69,16 @@ test_that("translates if_else()/ifelse()", {
     expr(fifelse(x < 0, 1, 2))
   )
 
+  # does not translate namespaced call
+  expect_equal(
+    capture_dot(df, base::ifelse(x < 0, 1, 2)),
+    expr(base::ifelse(x < 0, 1, 2))
+  )
+  expect_equal(
+    capture_dot(df, dplyr::if_else(x < 0, 1, 2)),
+    expr(dplyr::if_else(x < 0, 1, 2))
+  )
+
   # Handles unusual argument names/order
   expect_equal(
     capture_dot(df, ifelse(x < 0, n = 2, yes = 1)),
@@ -86,11 +96,24 @@ test_that("translates if_else()/ifelse()", {
   )
 })
 
-test_that("translates coalesce()", {
+test_that("translates coalesce() and replace_na()", {
   df <- data.frame(x = 1:5)
   expect_equal(
     capture_dot(df, coalesce(x, 1)),
     expr(fcoalesce(x, 1))
+  )
+  expect_equal(
+    capture_dot(df, replace_na(x, 1)),
+    expr(fcoalesce(x, 1))
+  )
+  # does not translate namespaced call
+  expect_equal(
+    capture_dot(df, dplyr::coalesce(x, 1)),
+    expr(dplyr::coalesce(x, 1))
+  )
+  expect_equal(
+    capture_dot(df, tidyr::replace_na(x, 1)),
+    expr(tidyr::replace_na(x, 1))
   )
 })
 
@@ -126,6 +149,12 @@ test_that("translates case_when()", {
     capture_dot(dt, case_when(x == 1 ~ n())),
     quote(fcase(x == 1, .N))
   )
+
+  # does not translate namespaced call
+  expect_equal(
+    capture_dot(dt, dplyr::case_when(x == 1 ~ 2)),
+    quote(dplyr::case_when(x == 1 ~ 2))
+  )
 })
 
 test_that("translates lag()/lead()", {
@@ -137,6 +166,15 @@ test_that("translates lag()/lead()", {
   expect_equal(
     capture_dot(df, lead(x, 2, default = 3)),
     expr(shift(x, n = 2, fill = 3, type = "lead"))
+  )
+  # does not translate namespaced call
+  expect_equal(
+    capture_dot(df, dplyr::lag(x)),
+    expr(dplyr::lag(x))
+  )
+  expect_equal(
+    capture_dot(df, dplyr::lead(x, 2, default = 3)),
+    expr(dplyr::lead(x, 2, default = 3))
   )
   # Errors with order_by
   expect_snapshot_error(


### PR DESCRIPTION
As shown below, tidyverse and base functions don't always behave the same as the similar data.table functions, so it would be nice to be able to avoid translation by using a namespaced function call.

On the other hand, this would make using dtplyr as a "drop in" speed-up for existing code slower if namespaced calls are used.

``` r
library(data.table)

dplyr::coalesce(factor('a'), factor('b'))
#> [1] a
#> Levels: a b
fcoalesce(factor('a'), factor('b'))
#> Error in fcoalesce(factor("a"), factor("b")): Item 2 is a factor but its levels are not identical to the first item's levels.

tidyr::replace_na(factor('a'), factor('b'))
#> Warning in `[<-.factor`(`*tmp*`, !is_complete(data), value =
#> structure(1L, .Label = "b", class = "factor")): invalid factor level, NA
#> generated
#> [1] a
#> Levels: a
fcoalesce(factor('a'), factor('b'))
#> Error in fcoalesce(factor("a"), factor("b")): Item 2 is a factor but its levels are not identical to the first item's levels.

dplyr::case_when(
  c(TRUE, FALSE) ~ factor('a'),
  c(TRUE, FALSE) ~ factor('b'))
#> Warning in `[<-.factor`(`*tmp*`, i, value = structure(1L, .Label = "b", class =
#> "factor")): invalid factor level, NA generated
#> [1] a    <NA>
#> Levels: a
fcase(
  c(TRUE, FALSE), factor('a'),
  c(TRUE, FALSE), factor('b'))
#> Error in fcase(c(TRUE, FALSE), factor("a"), c(TRUE, FALSE), factor("b")): Argument #2 and argument #4 are both factor but their levels are different.
          
base::ifelse(1, 'a', 'b')
#> [1] "a"
fifelse(1, 'a', 'b')
#> Error in fifelse(1, "a", "b"): Argument 'test' must be logical.

dplyr::if_else(c(TRUE, FALSE), factor('a'), factor('b'))
#> Warning in `[<-.factor`(`*tmp*`, i, value = structure(1L, .Label = "b", class =
#> "factor")): invalid factor level, NA generated
#> [1] a    <NA>
#> Levels: a
fifelse(c(TRUE, FALSE), factor('a'), factor('b'))
#> Error in fifelse(c(TRUE, FALSE), factor("a"), factor("b")): 'yes' and 'no' are both type factor but their levels are different.

dplyr::lag(1, 1:2)
#> Error: `n` must be a nonnegative integer scalar, not an integer vector of length 2.
shift(1, 1:2, type = 'lag')
#> [[1]]
#> [1] NA
#> 
#> [[2]]
#> [1] NA

dplyr::lead(1, 1:2)
#> Error: `n` must be a nonnegative integer scalar, not an integer vector of length 2.
shift(1, 1:2, type = 'lead')
#> [[1]]
#> [1] NA
#> 
#> [[2]]
#> [1] NA
```

<sup>Created on 2022-01-13 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
 