### PR TITLE
Properly handle groups in `count()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,10 @@
 
 * `mutate()` can now use `.keep`
 
+* `dtplyr` no longer directly depends on `ellipsis`
+
+* `count()` properly handles grouping variables (#356)
+
 # dtplyr 1.2.1
 
 * Fix for upcoming rlang release.

--- a/R/count.R
+++ b/R/count.R
@@ -96,7 +96,7 @@ check_name <- function(name, vars) {
       ))
     }
   } else if (!is_string(name)) {
-    abort("`name` must be a string", call = caller_env())
+    abort("`name` must be a string")
   }
 
   name

--- a/R/count.R
+++ b/R/count.R
@@ -17,11 +17,15 @@
 count.dtplyr_step <- function(.data, ..., wt = NULL, sort = FALSE, name = NULL) {
   if (!missing(...)) {
     out <- group_by(.data, ..., .add = TRUE)
+    .groups <- "drop"
   } else {
     out <- .data
+    .groups <- "keep"
   }
 
-  tally(out, wt = !!enquo(wt), sort = sort, name = name)
+  out <- tally_count(out, {{ wt }}, sort, name, .groups)
+
+  out
 }
 
 #' @export
@@ -52,21 +56,7 @@ add_count.data.table <- function(.data, ...) {
 #' @importFrom dplyr tally
 #' @export
 tally.dtplyr_step <- function(.data, wt = NULL, sort = FALSE, name = NULL) {
-  wt <- enquo(wt)
-  if (quo_is_null(wt)) {
-    n <- expr(n())
-  } else {
-    n <- expr(sum(!!wt, na.rm = TRUE))
-  }
-  name <- check_name(name, .data$groups)
-
-  out <- summarise(.data, !!name := !!n)
-
-  if (sort) {
-    out <- arrange(out, desc(!!sym(name)))
-  }
-
-  out
+  tally_count(.data, {{ wt }}, sort, name, "drop_last")
 }
 
 #' @export
@@ -76,6 +66,24 @@ tally.data.table <- function(.data, ...) {
 }
 
 # Helpers -----------------------------------------------------------------
+
+tally_count <- function(.data, wt = NULL, sort = FALSE, name = NULL, .groups = "drop_last") {
+  wt <- enquo(wt)
+  if (quo_is_null(wt)) {
+    n <- expr(n())
+  } else {
+    n <- expr(sum(!!wt, na.rm = TRUE))
+  }
+  name <- check_name(name, .data$groups)
+
+  out <- summarise(.data, !!name := !!n, .groups = .groups)
+
+  if (sort) {
+    out <- arrange(out, desc(!!sym(name)))
+  }
+
+  out
+}
 
 check_name <- function(name, vars) {
   if (is.null(name)) {

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -3,6 +3,6 @@
     Code
       dt %>% count(name = 10) %>% collect()
     Condition
-      Error in `tally_count()`:
+      Error in `check_name()`:
       ! `name` must be a string
 

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -3,6 +3,6 @@
     Code
       dt %>% count(name = 10) %>% collect()
     Condition
-      Error in `tally()`:
+      Error in `tally_count()`:
       ! `name` must be a string
 

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -8,7 +8,7 @@ test_that("can be used grouped or ungrouped", {
   )
   expect_equal(
     dt %>% group_by(x) %>% count() %>% collect(),
-    tibble(x = c(1, 2), n = c(3, 1))
+    tibble(x = c(1, 2), n = c(3, 1)) %>% group_by(x)
   )
 })
 


### PR DESCRIPTION
Closes #356

Edit: Worth mentioning for this review - `count()` and `tally()` approach groups differently. `tally()` follows the `summarize(.groups = "drop_last")` idea.

``` r
library(dplyr)

df <- tibble(x = c("a", "a", "b"), y = c("a", "a", "b"))

df %>%
  group_by(x, y) %>%
  count()
#> # A tibble: 2 × 3
#> # Groups:   x, y [2]
#>   x     y         n
#>   <chr> <chr> <int>
#> 1 a     a         2
#> 2 b     b         1

df %>%
  group_by(x, y) %>%
  tally()
#> # A tibble: 2 × 3
#> # Groups:   x [2]
#>   x     y         n
#>   <chr> <chr> <int>
#> 1 a     a         2
#> 2 b     b         1
```