### PR TITLE
`separate` errors when multiple columns provided as `col` 

### DIFF
--- a/R/step-subset-separate.R
+++ b/R/step-subset-separate.R
@@ -50,8 +50,7 @@ separate.dtplyr_step <- function(data, col, into,
     abort("`sep` must be a character vector.")
   }
 
-  sim_data <- simulate_vars(data)
-  col <- syms(names(tidyselect::eval_select(enquo(col), sim_data)))[[1]]
+  col <- as.symbol(tidyselect::vars_pull(data$vars, !!enquo(col)))
 
   into_length <- length(into)
 

--- a/tests/testthat/test-step-subset-separate.R
+++ b/tests/testthat/test-step-subset-separate.R
@@ -87,3 +87,10 @@ test_that("can use numeric `col` arg", {
   expect_equal(out$a, c("a", "a"))
   expect_equal(out$b, c("b", "b"))
 })
+
+test_that("errors on multiple columns in `col`", {
+  dt <- lazy_dt(tibble(x = c("a_b", "a_b"), y = x), "DT")
+
+  expect_error(separate(dt, c(x, y), into = c("left", "right")),
+               "must be size 1")
+})


### PR DESCRIPTION
Using `vars_pull` [as in tidyr](https://github.com/tidyverse/tidyr/blob/a008bcb1c5dd95cc67925914a720f72d5397c7ac/R/separate.R#L75) to get the same error. Prior to this PR the behavior was to select the first of the columns provided.

``` r
library(tidyr, warn.conflicts = FALSE)
library(data.table, warn.conflicts = FALSE)
devtools::load_all("/Users/mbp/Documents/GitHub/dtp")
#> ℹ Loading dtplyr
#> Warning: package 'dplyr' was built under R version 4.1.2

dt <- lazy_dt(tibble(x = c("a_a", "b_b", "c_c"), y = x))

dt %>% 
  separate(c(x, y), into = c("left", "right")) 
#> Error in `pull_as_location2()`:
#> ! Must extract column with a single valid subscript.
#> ✖ Subscript `var` has size 2 but must be size 1.
dt %>% 
  as_tibble() %>% 
  separate(c(x, y), into = c("left", "right")) 
#> Error in `pull_as_location2()`:
#> ! Must extract column with a single valid subscript.
#> ✖ Subscript `var` has size 2 but must be size 1.
```

<sup>Created on 2022-06-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>