### PR TITLE
Error when `where()` is used in `across()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dtplyr (development version)
 
+* An error now occurs when `where()` is used in `across()` (#271)
+
 * Custom functions can pass a quosure to `col` arg in `separate()` (#359)
 
 * `glue::glue()` and `stringr::str_glue()` now work inside `mutate()`/`transmute()` without needing

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -156,6 +156,7 @@ across_glue_mask <- function(.col, .fn, .caller_env) {
 }
 
 across_uses_where <- function(x) {
+  x <- quo_squash(x)
   if (is_call(x, "where")) {
     TRUE
   } else {

--- a/tests/testthat/_snaps/tidyeval-across.md
+++ b/tests/testthat/_snaps/tidyeval-across.md
@@ -31,6 +31,16 @@
       Error in `FUN()`:
       ! .fns argument to dtplyr::across() must contain a function or a formula
       x Problem with 1
+    Code
+      capture_across(dt, across(where(is.numeric)))
+    Condition
+      Error in `across_setup()`:
+      ! The use of `where()` is not supported by dtplyr.
+    Code
+      capture_across(dt, across(c(where(is.numeric), a)))
+    Condition
+      Error in `across_setup()`:
+      ! The use of `where()` is not supported by dtplyr.
 
 # if_all() gives informative errors
 

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -97,6 +97,8 @@ test_that("across() gives informative errors", {
   expect_snapshot(error = TRUE, {
     capture_across(dt, across(a, 1))
     capture_across(dt, across(a, list(1)))
+    capture_across(dt, across(where(is.numeric)))
+    capture_across(dt, across(c(where(is.numeric), a)))
   })
 })
 


### PR DESCRIPTION
Closes #271

The biggest thing this prevents is the "silent failure" cases.
``` r
library(dtplyr)
library(dplyr, warn.conflicts = FALSE)

df <- tibble(x = 1:3, y = c("a", "b", "c"), z = c("a", "a", "b"))

lazy_dt(df) %>%
  group_by(z) %>%
  summarize(across(!where(is.numeric), first))
#> Source: local data table [2 x 3]
#> Call:   `_DT1`[, .(x = first(x), y = first(y)), keyby = .(z)]
#> 
#>   z         x y    
#>   <chr> <int> <chr>
#> 1 a         1 a    
#> 2 b         3 c    
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```

Note: This can be updated later if https://github.com/r-lib/tidyselect/issues/226 is implemented.