### PR TITLE
Use `setorder()`  in `arrange()` when there is an implicit or explicit copy

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@
 
 * `count()` properly handles grouping variables (#356)
 
+* `arrange()` now utilizes `setorder()` when possible for improved performance (#364)
+
 # dtplyr 1.2.1
 
 * Fix for upcoming rlang release.

--- a/R/step-subset-arrange.R
+++ b/R/step-subset-arrange.R
@@ -24,8 +24,13 @@ arrange.dtplyr_step <- function(.data, ..., .by_group = FALSE) {
     return(.data)
   }
 
+  no_transmute <- !any(map_lgl(dots, ~ !is_symbol(.x) && !is_call(.x, "-", 1)))
   # Order without grouping then restore
   dots <- set_names(dots, NULL)
-  step <- step_subset(.data, i = call2("order", !!!dots), groups = character())
+  if ((.data$implicit_copy || .data$needs_copy) && no_transmute) {
+    step <- step_call(.data, "setorder", dots)
+  } else {
+    step <- step_subset(.data, i = call2("order", !!!dots), groups = character())
+  }
   step_group(step, groups = .data$groups)
 }

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -16,7 +16,7 @@ dt_eval <- function(x) {
 dt_funs <- c(
   "between", "CJ", "copy", "data.table", "dcast", "melt", "nafill",
   "fcase", "fcoalesce", "fifelse", "fintersect", "frank", "frankv", "fsetdiff", "funion",
-  "setcolorder", "setnames", "shift", "tstrsplit", "uniqueN"
+  "setcolorder", "setnames", "setorder", "shift", "tstrsplit", "uniqueN"
 )
 add_dt_wrappers <- function(env) {
   env_bind(env, !!!env_get_list(ns_env("data.table"), dt_funs))


### PR DESCRIPTION
Closes #364