### PR TITLE
Show user-level functions in tidyselect errors.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,8 @@ Suggests:
     testthat (>= 3.1.2),
     tidyr (>= 1.1.0),
     waldo (>= 0.3.1)
+Remotes:
+    r-lib/tidyselect
 VignetteBuilder: 
     knitr
 Config/Needs/website: tidyverse/tidytemplate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     lifecycle,
     rlang (>= 1.0.0),
     tibble,
-    tidyselect (>= 1.1.2),
+    tidyselect (>= 1.1.2.9000),
     vctrs (>= 0.4.1)
 Suggests:
     bench,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     dplyr (>= 1.0.3),
     glue,
     lifecycle,
-    rlang (>= 1.0.0),
+    rlang (>= 1.0.4),
     tibble,
     tidyselect (>= 1.1.2.9000),
     vctrs (>= 0.4.1)

--- a/R/step-subset-select.R
+++ b/R/step-subset-select.R
@@ -61,7 +61,10 @@ dtplyr_tidyselect <- function(.data, ...,
     abort("The use of `where()` is not supported by dtplyr.", call = .call)
   }
   sim_data <- simulate_vars(.data, drop_groups = .drop_groups)
-  tidyselect::eval_select(expr(c(!!!dots)), sim_data, allow_rename = .allow_rename)
+  tidyselect::eval_select(expr(c(!!!dots)), sim_data,
+    allow_rename = .allow_rename,
+    error_call = .call
+  )
 }
 
 selection_uses_where <- function(x) {

--- a/R/step-subset-select.R
+++ b/R/step-subset-select.R
@@ -61,7 +61,9 @@ dtplyr_tidyselect <- function(.data, ...,
     abort("The use of `where()` is not supported by dtplyr.", call = .call)
   }
   sim_data <- simulate_vars(.data, drop_groups = .drop_groups)
-  tidyselect::eval_select(expr(c(!!!dots)), sim_data,
+  tidyselect::eval_select(
+    expr(c(!!!dots)),
+    sim_data,
     allow_rename = .allow_rename,
     error_call = .call
   )

--- a/tests/testthat/_snaps/step-call.md
+++ b/tests/testthat/_snaps/step-call.md
@@ -22,7 +22,7 @@
     Code
       collect(drop_na(dt, "z"))
     Condition
-      Error in `chr_as_locations()`:
+      Error in `drop_na()`:
       ! Can't subset columns that don't exist.
       x Column `z` doesn't exist.
 

--- a/tests/testthat/_snaps/tidyeval-across.md
+++ b/tests/testthat/_snaps/tidyeval-across.md
@@ -52,6 +52,6 @@
       (expect_error(capture_if_all(dt, if_all(c(a = x, b = y)))))
     Output
       <error/rlang_error>
-      Error in `dtplyr_tidyselect()`:
+      Error in `if_all()`:
       ! Can't rename variables in this context.
 


### PR DESCRIPTION
Following the versions used for rlang and tidyselect in https://github.com/tidyverse/dplyr/commit/eaac641f6c20e050706b46db2558f79a92504d58