### PR TITLE
Adjust test for new tidyselect error message

### DIFF
--- a/tests/testthat/test-step-subset-separate.R
+++ b/tests/testthat/test-step-subset-separate.R
@@ -92,5 +92,5 @@ test_that("errors on multiple columns in `col`", {
   dt <- lazy_dt(tibble(x = c("a_b", "a_b"), y = x), "DT")
 
   expect_error(separate(dt, c(x, y), into = c("left", "right")),
-               "must be size 1")
+               "must select exactly one column")
 })


### PR DESCRIPTION
This fixes the failure when #384 was merged, and adjusts to the new tidyselect error message from https://github.com/r-lib/tidyselect/pull/277 