### PR TITLE
Inject syms that start with "." but aren't data.table syms

### DIFF
--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -18,6 +18,7 @@ dt_funs <- c(
   "fcase", "fcoalesce", "fifelse", "fintersect", "frank", "frankv", "fsetdiff", "funion",
   "setcolorder", "setnames", "setorder", "shift", "tstrsplit", "uniqueN"
 )
+dt_symbols <- c(".SD", ".BY", ".N", ".I", ".GRP", ".NGRP")
 add_dt_wrappers <- function(env) {
   env_bind(env, !!!env_get_list(ns_env("data.table"), dt_funs))
 }
@@ -77,7 +78,7 @@ dt_squash <- function(x, env, data, j = TRUE) {
 
       if (var %in% c("T", "F")) {
         as.logical(var)
-      } else if (nchar(x) > 0 && substr(var, 1, 1) == ".") {
+      } else if (var %in% dt_symbols) {
         # data table pronouns are bound to NULL
         x
       } else if (!var %in% data$vars && env_has(env, var, inherit = TRUE)) {

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -20,6 +20,9 @@ test_that("existing non-variables get inlined", {
   n <- 10
   expect_equal(capture_dot(dt, x + n), quote(x + 10))
   expect_equal(capture_dot(dt, x + m), quote(x + m))
+  # even if they start with "." (#386)
+  .n <- 20
+  expect_equal(capture_dot(dt, x + .n), quote(x + 20))
 })
 
 test_that("unless we're operating in the global environment", {


### PR DESCRIPTION
closes #386

``` r
library(dplyr, w = FALSE)
library(dtplyr, w = FALSE)

f <- function(x, .v) {
  mutate(x, a = .v)
}

x <- data.frame(a = "y")

lazy_dt(x) |>
  f(.v = "injected")
#> Source: local data table [1 x 1]
#> Call:   copy(`_DT1`)[, `:=`(a = "injected")]
#> 
#>   a       
#>   <chr>   
#> 1 injected
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```

<sup>Created on 2022-08-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>