### PR TITLE
Implement `pick()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 * `min_rank()`, `dense_rank()`, `percent_rank()`, & `cume_dist()` are now translated
   to their `data.table` equivalents (#396)
+  
+* `pick()` is now translated (#341)
+
+* `across()` output can now be used as a data frame (#341)
 
 * `names_glue` now works in `pivot_wider()` when `names_from` contains `NA`s (#394)
 

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -3,10 +3,10 @@ capture_across <- function(data, x, j = TRUE) {
   dt_squash_across(get_expr(x), get_env(x), data, j)
 }
 
-dt_squash_across <- function(call, env, data, j = j, is_top_across = TRUE) {
+dt_squash_across <- function(call, env, data, j = j, is_top = TRUE) {
   call <- match.call(dplyr::across, call, expand.dots = FALSE, envir = env)
   out <- across_setup(data, call, env, allow_rename = TRUE, j = j, fn = "across()")
-  if (is_false(is_top_across)) {
+  if (is_false(is_top)) {
     out <- call2("data.table", !!!out)
   }
   out

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -3,9 +3,13 @@ capture_across <- function(data, x, j = TRUE) {
   dt_squash_across(get_expr(x), get_env(x), data, j)
 }
 
-dt_squash_across <- function(call, env, data, j = j) {
+dt_squash_across <- function(call, env, data, j = j, is_top_across = TRUE) {
   call <- match.call(dplyr::across, call, expand.dots = FALSE, envir = env)
-  across_setup(data, call, env, allow_rename = TRUE, j = j, fn = "across()")
+  out <- across_setup(data, call, env, allow_rename = TRUE, j = j, fn = "across()")
+  if (is_false(is_top_across)) {
+    out <- call2("data.table", !!!out)
+  }
+  out
 }
 
 capture_if_all <- function(data, x, j = TRUE) {

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -158,6 +158,26 @@ test_that("across() .cols is evaluated in across()'s calling environment", {
   )
 })
 
+test_that("across() output can be used as a data frame", {
+  df <- lazy_dt(tibble(x = 1:3, y = 1:3, z = c("a", "a", "b")))
+  res <- df %>%
+    mutate(across_df = rowSums(across(c(x, y), ~ .x + 1))) %>%
+    collect()
+
+  expect_named(res, c("x", "y", "z", "across_df"))
+  expect_equal(res$across_df, c(4, 6, 8))
+})
+
+test_that("pick() works", {
+  df <- lazy_dt(tibble(x = 1:3, y = 1:3, z = c("a", "a", "b")))
+  res <- df %>%
+    mutate(row_sum = rowSums(pick(x, y))) %>%
+    collect()
+
+  expect_named(res, c("x", "y", "z", "row_sum"))
+  expect_equal(res$row_sum, c(2, 4, 6))
+})
+
 # if_all ------------------------------------------------------------------
 
 test_that("if_all collapses multiple expresions", {
@@ -268,7 +288,7 @@ test_that("if_all() can handle empty selection", {
   )
 })
 
-test_that("across() .cols is evaluated in across()'s calling environment", {
+test_that("if_all() .cols is evaluated in across()'s calling environment", {
   dt <- lazy_dt(data.frame(y = 1))
   fun <- function(x) capture_if_all(dt, if_all(all_of(x)))
   expect_equal(

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -167,7 +167,7 @@ test_that("across() output can be used as a data frame", {
   expect_named(res, c("x", "y", "z", "across_df"))
   expect_equal(res$across_df, c(4, 6, 8))
 
-  expr <- dt_squash(expr(across(c(x, y), ~ .x + 1)), df$env, df, is_top_across = FALSE)
+  expr <- dt_squash(expr(across(c(x, y), ~ .x + 1)), df$env, df, is_top = FALSE)
   expect_equal(expr, expr(data.table(x = x + 1, y = y + 1)))
 })
 
@@ -180,8 +180,11 @@ test_that("pick() works", {
   expect_named(res, c("x", "y", "z", "row_sum"))
   expect_equal(res$row_sum, c(2, 4, 6))
 
-  expr <- dt_squash(expr(pick(x, y)), df$env, df, is_top_across = FALSE)
+  expr <- dt_squash(expr(pick(x, y)), df$env, df, is_top = FALSE)
   expect_equal(expr, expr(data.table(x = x, y = y)))
+
+  # Top level pick works
+  expect_equal(group_by(df, pick(x, y))$groups, c("x", "y"))
 })
 
 # if_all ------------------------------------------------------------------

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -166,6 +166,9 @@ test_that("across() output can be used as a data frame", {
 
   expect_named(res, c("x", "y", "z", "across_df"))
   expect_equal(res$across_df, c(4, 6, 8))
+
+  expr <- dt_squash(expr(across(c(x, y), ~ .x + 1)), df$env, df, is_top_across = FALSE)
+  expect_equal(expr, expr(data.table(x = x + 1, y = y + 1)))
 })
 
 test_that("pick() works", {
@@ -176,6 +179,9 @@ test_that("pick() works", {
 
   expect_named(res, c("x", "y", "z", "row_sum"))
   expect_equal(res$row_sum, c(2, 4, 6))
+
+  expr <- dt_squash(expr(pick(x, y)), df$env, df, is_top_across = FALSE)
+  expect_equal(expr, expr(data.table(x = x, y = y)))
 })
 
 # if_all ------------------------------------------------------------------


### PR DESCRIPTION
Closes #341 

Overview: Translate `pick()` and `across()` calls to a `data.table()` call.

``` r
devtools::load_all(".")
#> ℹ Loading dtplyr

df <- lazy_dt(tibble(x = 1:3, y = 1:3, z = c("a", "a", "b")))

df %>%
  mutate(row_sum = rowSums(pick(x, y)))
#> Source: local data table [3 x 4]
#> Call:   copy(`_DT1`)[, `:=`(row_sum = rowSums(data.table(x = x, y = y)))]
#> 
#>       x     y z     row_sum
#>   <int> <int> <chr>   <dbl>
#> 1     1     1 a           2
#> 2     2     2 a           4
#> 3     3     3 b           6
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results

df %>%
  mutate(new = rowSums(across(c(x, y), ~ .x + 1)))
#> Source: local data table [3 x 4]
#> Call:   copy(`_DT1`)[, `:=`(new = rowSums(data.table(x = x + 1, y = y + 
#>     1)))]
#> 
#>       x     y z       new
#>   <int> <int> <chr> <dbl>
#> 1     1     1 a         4
#> 2     2     2 a         6
#> 3     3     3 b         8
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```