### PR TITLE
Use snapshots for errors that dplyr owns now

### DIFF
--- a/tests/testthat/_snaps/step-subset-slice.md
+++ b/tests/testthat/_snaps/step-subset-slice.md
@@ -4,32 +4,42 @@
       slice_head(dt, 5)
     Condition
       Error in `slice_head()`:
-      ! `n` must be explicitly named.
-      i Did you mean `slice_head(n = 5)`?
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = 5
+      i Did you forget to name an argument?
     Code
       slice_tail(dt, 5)
     Condition
       Error in `slice_tail()`:
-      ! `n` must be explicitly named.
-      i Did you mean `slice_tail(n = 5)`?
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = 5
+      i Did you forget to name an argument?
     Code
       slice_min(dt, x, 5)
     Condition
-      Error in `slice_min()`:
-      ! `n` must be explicitly named.
-      i Did you mean `slice_min(n = 5)`?
+      Error in `slice_min_max()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = 5
+      i Did you forget to name an argument?
     Code
       slice_max(dt, x, 5)
     Condition
-      Error in `slice_max()`:
-      ! `n` must be explicitly named.
-      i Did you mean `slice_max(n = 5)`?
+      Error in `slice_min_max()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = 5
+      i Did you forget to name an argument?
     Code
       slice_sample(dt, 5)
     Condition
       Error in `slice_sample()`:
-      ! `n` must be explicitly named.
-      i Did you mean `slice_sample(n = 5)`?
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = 5
+      i Did you forget to name an argument?
 
 ---
 
@@ -37,12 +47,12 @@
       slice_min(dt)
     Condition
       Error in `slice_min()`:
-      ! `order_by` is absent but must be supplied.
+      ! argument `order_by` is missing, with no default.
     Code
       slice_max(dt)
     Condition
       Error in `slice_max()`:
-      ! `order_by` is absent but must be supplied.
+      ! argument `order_by` is missing, with no default.
 
 # check_slice_catches common errors
 

--- a/tests/testthat/_snaps/step-subset-slice.md
+++ b/tests/testthat/_snaps/step-subset-slice.md
@@ -1,3 +1,49 @@
+# slice_*() checks for empty ...
+
+    Code
+      slice_head(dt, 5)
+    Condition
+      Error in `slice_head()`:
+      ! `n` must be explicitly named.
+      i Did you mean `slice_head(n = 5)`?
+    Code
+      slice_tail(dt, 5)
+    Condition
+      Error in `slice_tail()`:
+      ! `n` must be explicitly named.
+      i Did you mean `slice_tail(n = 5)`?
+    Code
+      slice_min(dt, x, 5)
+    Condition
+      Error in `slice_min()`:
+      ! `n` must be explicitly named.
+      i Did you mean `slice_min(n = 5)`?
+    Code
+      slice_max(dt, x, 5)
+    Condition
+      Error in `slice_max()`:
+      ! `n` must be explicitly named.
+      i Did you mean `slice_max(n = 5)`?
+    Code
+      slice_sample(dt, 5)
+    Condition
+      Error in `slice_sample()`:
+      ! `n` must be explicitly named.
+      i Did you mean `slice_sample(n = 5)`?
+
+---
+
+    Code
+      slice_min(dt)
+    Condition
+      Error in `slice_min()`:
+      ! `order_by` is absent but must be supplied.
+    Code
+      slice_max(dt)
+    Condition
+      Error in `slice_max()`:
+      ! `order_by` is absent but must be supplied.
+
 # check_slice_catches common errors
 
     Code

--- a/tests/testthat/test-step-subset-slice.R
+++ b/tests/testthat/test-step-subset-slice.R
@@ -127,14 +127,19 @@ test_that("arguments to sample are passed along", {
 
 test_that("slice_*() checks for empty ...", {
   dt <- lazy_dt(data.frame(x = 1:10))
-  expect_error(slice_head(dt, 5), class = "rlib_error_dots_nonempty")
-  expect_error(slice_tail(dt, 5), class = "rlib_error_dots_nonempty")
-  expect_error(slice_min(dt, x, 5), class = "rlib_error_dots_nonempty")
-  expect_error(slice_max(dt, x, 5), class = "rlib_error_dots_nonempty")
-  expect_error(slice_sample(dt, 5), class = "rlib_error_dots_nonempty")
 
-  expect_error(slice_min(dt), "missing")
-  expect_error(slice_max(dt), "missing")
+  expect_snapshot(error = TRUE, {
+    slice_head(dt, 5)
+    slice_tail(dt, 5)
+    slice_min(dt, x, 5)
+    slice_max(dt, x, 5)
+    slice_sample(dt, 5)
+  })
+
+  expect_snapshot(error = TRUE, {
+    slice_min(dt)
+    slice_max(dt)
+  })
 })
 
 test_that("slice_*() checks for constant n= and prop=", {


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`slice_*()` now handles some of the checks in the generic itself, and the error messages it throws are different from what you had before. I've made these snapshot error tests since dplyr really owns the error message now, and we don't want this to fail on CRAN if dplyr ever changes it.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!