### PR TITLE
`across()` ignores variables passed in `.by`

### DIFF
--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -97,13 +97,13 @@ mutate.dtplyr_step <- function(.data, ...,
                                .by = NULL,
                                .keep = c("all", "used", "unused", "none"),
                                .before = NULL, .after = NULL) {
-  all_dots <- capture_new_vars(.data, ...)
+  by <- compute_by({{ .by }}, .data, by_arg = ".by", data_arg = ".data")
+
+  all_dots <- capture_new_vars(.data, ..., .by = by)
   trivial_dot <- imap(all_dots, ~ is_symbol(.x) && sym(.y) == .x && .y %in% .data$vars)
   dots <- all_dots[!as.vector(trivial_dot, "logical")]
   dots_list <- process_new_vars(.data, dots)
   dots <- dots_list$dots
-
-  by <- compute_by({{ .by }}, .data, by_arg = ".by", data_arg = ".data")
 
   if (is_null(dots) || is_empty(dots)) {
     out <- .data

--- a/R/step-subset-filter.R
+++ b/R/step-subset-filter.R
@@ -21,9 +21,8 @@
 # exported onLoad
 filter.dtplyr_step <- function(.data, ..., .by = NULL, .preserve = FALSE) {
   check_filter(...)
-  dots <- capture_dots(.data, ..., .j = FALSE)
-
   by <- compute_by({{ .by }}, .data, by_arg = ".by", data_arg = ".data")
+  dots <- capture_dots(.data, ..., .j = FALSE, .by = by)
 
   if (filter_by_lgl_col(dots)) {
     # Suppress data.table warning when filtering with a logical variable

--- a/R/step-subset-summarise.R
+++ b/R/step-subset-summarise.R
@@ -21,9 +21,6 @@
 #'   group_by(cyl) %>%
 #'   summarise(across(disp:wt, mean))
 summarise.dtplyr_step <- function(.data, ..., .by = NULL, .groups = NULL) {
-  dots <- capture_dots(.data, ...)
-  check_summarise_vars(dots)
-
   by <- compute_by({{ .by }}, .data, by_arg = ".by", data_arg = ".data")
   if (by$uses_by) {
     group_vars <- by$names
@@ -31,6 +28,9 @@ summarise.dtplyr_step <- function(.data, ..., .by = NULL, .groups = NULL) {
   } else {
     group_vars <- .data$groups
   }
+
+  dots <- capture_dots(.data, ..., .by = by)
+  check_summarise_vars(dots)
 
   if (length(dots) == 0) {
     if (length(group_vars) == 0) {

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -28,7 +28,11 @@ globalVariables(dt_funs)
 # data.table. The goal is to get the majority of real-world code to work,
 # without aiming for 100% compliance.
 
-capture_dots <- function(.data, ..., .j = TRUE) {
+capture_dots <- function(.data, ..., .j = TRUE, .by = new_by()) {
+  if (.by$uses_by) {
+    .data$groups <- .by$names
+  }
+
   dots <- enquos(..., .named = .j)
   dots <- map(dots, dt_squash, data = .data, j = .j, is_top = TRUE)
 
@@ -41,7 +45,11 @@ capture_dots <- function(.data, ..., .j = TRUE) {
   unlist(dots, recursive = FALSE)
 }
 
-capture_new_vars <- function(.data, ...) {
+capture_new_vars <- function(.data, ..., .by = new_by()) {
+  if (.by$uses_by) {
+    .data$groups <- .by$names
+  }
+
   dots <- as.list(enquos(..., .named = TRUE))
   for (i in seq_along(dots)) {
     dot <- dots[[i]]

--- a/tests/testthat/test-tidyeval-across.R
+++ b/tests/testthat/test-tidyeval-across.R
@@ -187,6 +187,20 @@ test_that("pick() works", {
   expect_equal(group_by(df, pick(x, y))$groups, c("x", "y"))
 })
 
+test_that("`across()` ignores variables in `.by`, #412", {
+  dt <- lazy_dt(data.table(x = 1:3, y = c("a", "a", "b")))
+  step <- dt %>%
+    mutate(across(everything(), ~ .x + 1), .by = y)
+
+  expect_equal(as_tibble(step), tibble(x = 2:4, y = c("a", "a", "b")))
+  expect_true(length(step$groups) == 0)
+
+  step <- dt %>%
+    summarize(across(everything(), sum), .by = y)
+
+  expect_equal(as_tibble(step), tibble(y = c("a", "b"), x = c(3, 3)))
+})
+
 # if_all ------------------------------------------------------------------
 
 test_that("if_all collapses multiple expresions", {


### PR DESCRIPTION
Closes #412 

@hadley - found this one while looking at the failed revdep (it’s unrelated).

As far as I can tell the failed check isn’t a real failure.