### PR TITLE
Drop `crayon` in favor of `cli`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Depends:
     R (>= 3.3)
 Imports:
     cli (>= 3.4.0),
-    crayon,
     data.table (>= 1.13.0),
     dplyr (>= 1.1.0),
     glue,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # dtplyr (development version)
 
+## Minor improvements and bug fixes
+
+* `dtplyr` no longer directly depends on `crayon`.
+
 # dtplyr 1.3.0
 
 ## Breaking changes

--- a/R/step.R
+++ b/R/step.R
@@ -179,23 +179,23 @@ pull.dtplyr_step <- function(.data, var = -1, name = NULL) {
 print.dtplyr_step <- function(x, ...) {
   dt <- as.data.table(x)
 
-  cat_line(crayon::bold("Source: "), "local data table ", dplyr::dim_desc(dt))
+  cat_line(cli::style_bold("Source: "), "local data table ", dplyr::dim_desc(dt))
   if (length(x$groups) > 0) {
-    cat_line(crayon::bold("Groups: "), paste(x$groups, collapse = ", "))
+    cat_line(cli::style_bold("Groups: "), paste(x$groups, collapse = ", "))
   }
   if (length(x$locals) > 0) {
-    cat_line(crayon::bold("Call:"))
+    cat_line(cli::style_bold("Call:"))
     for (var in names(x$locals)) {
       cat_line("  ", var, " <- ", expr_deparse(x$locals[[var]]))
     }
     cat_line("  ", expr_text(dt_call(x)))
   } else {
-    cat_line(crayon::bold("Call:   "), expr_text(dt_call(x)))
+    cat_line(cli::style_bold("Call:   "), expr_text(dt_call(x)))
   }
   cat_line()
   cat_line(format(as_tibble(dt, .name_repair = "minimal"), n = 6)[-1]) # Hack to remove "A tibble" line
   cat_line()
-  cat_line(crayon::silver(
+  cat_line(cli::col_silver(
     "# Use as.data.table()/as.data.frame()/as_tibble() to access results"
   ))
 


### PR DESCRIPTION
Closes #418 

@eutwt I am going to merge this since it is such a small change (we already depend on `cli`).