### PR TITLE
Translate `consecutive_id()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # dtplyr (development version)
 
+## New features
+
+* `consecutive_id()` is now mapped to `data.table::rleid()`
+
 # dtplyr 1.3.1
 
 * Fix for failing R CMD check.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## New features
 
-* `consecutive_id()` is now mapped to `data.table::rleid()`
+* `consecutive_id()` is now mapped to `data.table::rleid()`.
+  Note: `rleid()` only accepts vector inputs and cannot be used with data frame inputs.
 
 # dtplyr 1.3.1
 

--- a/R/tidyeval-across.R
+++ b/R/tidyeval-across.R
@@ -4,7 +4,7 @@ capture_across <- function(data, x, j = TRUE) {
 }
 
 dt_squash_across <- function(call, env, data, j = j, is_top = TRUE) {
-  call <- match.call(dplyr::across, call, expand.dots = FALSE, envir = env)
+  call <- call_match(call, dplyr::across, dots_expand = FALSE, dots_env = env)
   out <- across_setup(data, call, env, allow_rename = TRUE, j = j, fn = "across()")
   if (is_false(is_top)) {
     out <- call2("data.table", !!!out)
@@ -18,7 +18,7 @@ capture_if_all <- function(data, x, j = TRUE) {
 }
 
 dt_squash_if <- function(call, env, data, j = j, reduce = "&") {
-  call <- match.call(dplyr::if_any, call, expand.dots = FALSE, envir = env)
+  call <- call_match(call, dplyr::if_any, dots_expand = FALSE, dots_env = env)
   if (reduce == "&") {
     fn <- "if_all()"
   } else {

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -16,7 +16,7 @@ dt_eval <- function(x) {
 dt_funs <- c(
   "between", "CJ", "copy", "data.table", "dcast", "melt", "nafill",
   "fcase", "fcoalesce", "fifelse", "fintersect", "frank", "frankv", "fsetdiff", "funion",
-  "setcolorder", "setnames", "setorder", "shift", "tstrsplit", "uniqueN"
+  "rleid", "setcolorder", "setnames", "setorder", "shift", "tstrsplit", "uniqueN"
 )
 dt_symbols <- c(".SD", ".BY", ".N", ".I", ".GRP", ".NGRP")
 add_dt_wrappers <- function(env) {
@@ -249,6 +249,10 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
       call$.envir <- quote(.SD)
     }
     call
+  } else if (is_call(x, "consecutive_id")) {
+    x[[1]] <- expr(rleid)
+    x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)
+    x
   } else {
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)
     x

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -171,9 +171,9 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x
   } else if (is_call(x, c("if_else", "ifelse"))) {
     if (is_call(x, "if_else")) {
-      x <- unname(match.call(dplyr::if_else, x))
+      x <- unname(call_match(x, dplyr::if_else))
     } else {
-      x <- unname(match.call(ifelse, x))
+      x <- unname(call_match(x, ifelse))
     }
 
     x[[1]] <- quote(fifelse)
@@ -182,10 +182,10 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
   } else if (is_call(x, c("lag", "lead"))) {
     if (is_call(x, "lag")) {
       type <- "lag"
-      call <- match.call(dplyr::lag, x)
+      call <- call_match(x, dplyr::lag)
     } else {
       type <- "lead"
-      call <- match.call(dplyr::lead, x)
+      call <- call_match(x, dplyr::lead)
     }
     call[-1] <- lapply(call[-1], dt_squash, env = env, data = data, j = j)
 
@@ -206,7 +206,7 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
   } else if (is_call(x, "n", n = 0)) {
     quote(.N)
   } else if (is_call(x, "n_distinct")) {
-    x <- match.call(dplyr::n_distinct, x, expand.dots = FALSE)
+    x <- call_match(x, dplyr::n_distinct, dots_expand = FALSE)
     dots <- x$...
     if (length(dots) == 1) {
       vec <- dots[[1]]

--- a/man/arrange.dtplyr_step.Rd
+++ b/man/arrange.dtplyr_step.Rd
@@ -9,8 +9,9 @@
 \arguments{
 \item{.data}{A \code{\link[=lazy_dt]{lazy_dt()}}.}
 
-\item{...}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Variables, or functions of
-variables. Use \code{\link[dplyr:desc]{desc()}} to sort a variable in descending order.}
+\item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Variables, or
+functions of variables. Use \code{\link[dplyr:desc]{desc()}} to sort a variable in descending
+order.}
 
 \item{.by_group}{If \code{TRUE}, will sort first by grouping variable. Applies to
 grouped data frames only.}

--- a/man/count.dtplyr_step.Rd
+++ b/man/count.dtplyr_step.Rd
@@ -9,9 +9,10 @@
 \arguments{
 \item{x}{A \code{\link[=lazy_dt]{lazy_dt()}}}
 
-\item{...}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Variables to group by.}
+\item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Variables to group
+by.}
 
-\item{wt}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Frequency weights.
+\item{wt}{<\code{\link[rlang:args_data_masking]{data-masking}}> Frequency weights.
 Can be \code{NULL} or a variable:
 \itemize{
 \item If \code{NULL} (the default), counts the number of rows in each group.

--- a/man/distinct.dtplyr_step.Rd
+++ b/man/distinct.dtplyr_step.Rd
@@ -9,8 +9,8 @@
 \arguments{
 \item{.data}{A \code{\link[=lazy_dt]{lazy_dt()}}}
 
-\item{...}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Optional variables to use
-when determining uniqueness. If there are multiple rows for a given
+\item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Optional variables to
+use when determining uniqueness. If there are multiple rows for a given
 combination of inputs, only the first row will be preserved. If omitted,
 will use all variables in the data frame.}
 

--- a/man/filter.dtplyr_step.Rd
+++ b/man/filter.dtplyr_step.Rd
@@ -9,10 +9,11 @@
 \arguments{
 \item{.data}{A \code{\link[=lazy_dt]{lazy_dt()}}.}
 
-\item{...}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Expressions that return a
-logical value, and are defined in terms of the variables in \code{.data}.
-If multiple expressions are included, they are combined with the \code{&} operator.
-Only rows for which all conditions evaluate to \code{TRUE} are kept.}
+\item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Expressions that
+return a logical value, and are defined in terms of the variables in
+\code{.data}. If multiple expressions are included, they are combined with the
+\code{&} operator. Only rows for which all conditions evaluate to \code{TRUE} are
+kept.}
 
 \item{.by}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 

--- a/man/mutate.dtplyr_step.Rd
+++ b/man/mutate.dtplyr_step.Rd
@@ -16,7 +16,7 @@
 \arguments{
 \item{.data}{A \code{\link[=lazy_dt]{lazy_dt()}}.}
 
-\item{...}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Name-value pairs.
+\item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Name-value pairs.
 The name gives the name of the column in the output.
 
 The value can be:

--- a/man/slice.dtplyr_step.Rd
+++ b/man/slice.dtplyr_step.Rd
@@ -21,8 +21,8 @@
 \arguments{
 \item{.data}{A \code{\link[=lazy_dt]{lazy_dt()}}.}
 
-\item{...}{For \code{slice()}: <\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Integer row
-values.
+\item{...}{For \code{slice()}: <\code{\link[rlang:args_data_masking]{data-masking}}>
+Integer row values.
 
 Provide either positive values to keep, or negative values to drop.
 The values provided must be either all positive or all negative.
@@ -47,9 +47,9 @@ A negative value of \code{n} or \code{prop} will be subtracted from the group
 size. For example, \code{n = -2} with a group of 5 rows will select 5 - 2 = 3
 rows; \code{prop = -0.25} with 8 rows will select 8 * (1 - 0.25) = 6 rows.}
 
-\item{order_by}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Variable or function
-of variables to order by. To order by multiple variables, wrap them in a
-data frame or tibble.}
+\item{order_by}{<\code{\link[rlang:args_data_masking]{data-masking}}> Variable or
+function of variables to order by. To order by multiple variables, wrap
+them in a data frame or tibble.}
 
 \item{with_ties}{Should ties be kept together? The default, \code{TRUE},
 may return more rows than you request. Use \code{FALSE} to ignore ties,

--- a/man/summarise.dtplyr_step.Rd
+++ b/man/summarise.dtplyr_step.Rd
@@ -9,8 +9,8 @@
 \arguments{
 \item{.data}{A \code{\link[=lazy_dt]{lazy_dt()}}.}
 
-\item{...}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Name-value pairs of summary
-functions. The name will be the name of the variable in the result.
+\item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Name-value pairs of
+summary functions. The name will be the name of the variable in the result.
 
 The value can be:
 \itemize{

--- a/man/transmute.dtplyr_step.Rd
+++ b/man/transmute.dtplyr_step.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{.data}{A \code{\link[=lazy_dt]{lazy_dt()}}.}
 
-\item{...}{<\code{\link[dplyr:dplyr_data_masking]{data-masking}}> Name-value pairs.
+\item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Name-value pairs.
 The name gives the name of the column in the output.
 
 The value can be:

--- a/tests/testthat/_snaps/step.md
+++ b/tests/testthat/_snaps/step.md
@@ -15,7 +15,7 @@
       4  21.4     6   258   110  3.08  3.22  19.4     1     0     3     1
       5  18.7     8   360   175  3.15  3.44  17.0     0     0     3     2
       6  18.1     6   225   105  2.76  3.46  20.2     1     0     3     1
-      # ... with 26 more rows
+      # i 26 more rows
       
       # Use as.data.table()/as.data.frame()/as_tibble() to access results
     Code
@@ -33,7 +33,7 @@
       4  21.4     6   258   110  3.08  3.22  19.4     1     0     3     1
       5  18.7     8   360   175  3.15  3.44  17.0     0     0     3     2
       6  18.1     6   225   105  2.76  3.46  20.2     1     0     3     1
-      # ... with 26 more rows
+      # i 26 more rows
       
       # Use as.data.table()/as.data.frame()/as_tibble() to access results
     Code
@@ -52,7 +52,7 @@
       4  21.4     6   258   110  3.08  3.22  19.4     1     0     3     1    10
       5  18.7     8   360   175  3.15  3.44  17.0     0     0     3     2    10
       6  18.1     6   225   105  2.76  3.46  20.2     1     0     3     1    10
-      # ... with 26 more rows
+      # i 26 more rows
       
       # Use as.data.table()/as.data.frame()/as_tibble() to access results
 

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -207,6 +207,14 @@ test_that("properly handles anonymous functions, #362", {
   )
 })
 
+test_that("translates `consecutive_id()`", {
+  df <- data.frame(x = 1:5, y = 1:5)
+  expect_equal(
+    capture_dot(df, consecutive_id(x, y)),
+    expr(rleid(x, y))
+  )
+})
+
 # evaluation --------------------------------------------------------------
 
 test_that("can access functions in local env", {


### PR DESCRIPTION
Closes #414 

Overview:
* Translate `consecutive_id()` to `rleid()`
* Minor code consistency update: Replace `match.call()` with `call_match()` in `tidyeval.R`. We were using both in different places.