### PR TITLE
Translate `case_match()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 * `consecutive_id()` is now mapped to `data.table::rleid()`.
   Note: `rleid()` only accepts vector inputs and cannot be used with data frame inputs.
   
+* `case_match()` is now translated to `fcase()`.
+  
 ## Minor improvements and bug fixes
 
 * Can namespace calls to `desc()` (#427).

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -362,7 +362,11 @@ check_one_arg <- function(x) {
 
 prep_case_match_dot <- function(dot, .x) {
   lhs <- f_lhs(dot)
-  lhs <- call2("%in%", .x, lhs)
+  if (is.character(lhs) || is.numeric(lhs)) {
+    lhs <- call2("==", .x, lhs)
+  } else {
+    lhs <- call2("%in%", .x, lhs)
+  }
   f_lhs(dot) <- lhs
   dot
 }

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -156,13 +156,13 @@ test_that("translates case_match()", {
   # Works without `.default`
   expect_equal(
     capture_dot(dt, case_match(x, c(1, 2) ~ 1, 3 ~ 2)),
-    quote(fcase(x %in% c(1, 2), 1, x %in% 3, 2))
+    quote(fcase(x %in% c(1, 2), 1, x == 3, 2))
   )
 
   # Works with `.default`
   expect_equal(
     capture_dot(dt, case_match(x, c(1, 2) ~ 1, 3 ~ 2, .default = 3)),
-    quote(fcase(x %in% c(1, 2), 1, x %in% 3, 2, rep(TRUE, .N), 3))
+    quote(fcase(x %in% c(1, 2), 1, x == 3, 2, rep(TRUE, .N), 3))
   )
 })
 

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -150,6 +150,22 @@ test_that("translates case_when()", {
   )
 })
 
+test_that("translates case_match()", {
+  dt <- lazy_dt(data.frame(x = 1:5))
+
+  # Works without `.default`
+  expect_equal(
+    capture_dot(dt, case_match(x, c(1, 2) ~ 1, 3 ~ 2)),
+    quote(fcase(x %in% c(1, 2), 1, x %in% 3, 2))
+  )
+
+  # Works with `.default`
+  expect_equal(
+    capture_dot(dt, case_match(x, c(1, 2) ~ 1, 3 ~ 2, .default = 3)),
+    quote(fcase(x %in% c(1, 2), 1, x %in% 3, 2, rep(TRUE, .N), 3))
+  )
+})
+
 test_that("translates lag()/lead()", {
   df <- data.frame(x = 1:5, y = 1:5)
   expect_equal(


### PR DESCRIPTION
Closes #430

Overview:
Translates `case_match()` to `case_when()`. Then uses `dt_squash_call()` to translate `case_when()` to `fcase()`.