### PR TITLE
Avoid altering parent groups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 
 * `case_when(.default = )` now works.
 
+* `.by` no longer alters grouping in prior steps (#439)
+
 # dtplyr 1.3.1
 
 * Fix for failing R CMD check.

--- a/R/step-mutate.R
+++ b/R/step-mutate.R
@@ -5,7 +5,7 @@ step_mutate <- function(parent, new_vars = list(), use_braces = FALSE, by = new_
   vars <- setdiff(vars, names(new_vars)[var_is_null & is_last])
 
   if (by$uses_by) {
-    parent$groups <- by$names
+    parent <- step_group(parent, by$names)
   }
 
   out <- new_step(

--- a/R/step-subset.R
+++ b/R/step-subset.R
@@ -38,7 +38,7 @@ step_subset_i <- function(parent, i, by = new_by()) {
   }
 
   if (by$uses_by) {
-    parent$groups <- by$names
+    parent <- step_group(parent, by$names)
   }
 
   if (length(parent$groups) > 0) {
@@ -75,7 +75,7 @@ step_subset_j <- function(parent,
   }
 
   if (by$uses_by) {
-    parent$groups <- by$names
+    parent <- step_group(parent, by$names)
   }
 
   out <- step_subset(

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -30,7 +30,7 @@ globalVariables(dt_funs)
 
 capture_dots <- function(.data, ..., .j = TRUE, .by = new_by()) {
   if (.by$uses_by) {
-    .data$groups <- .by$names
+    .data <- step_group(.data, .by$names)
   }
 
   dots <- enquos(..., .named = .j)
@@ -47,7 +47,7 @@ capture_dots <- function(.data, ..., .j = TRUE, .by = new_by()) {
 
 capture_new_vars <- function(.data, ..., .by = new_by()) {
   if (.by$uses_by) {
-    .data$groups <- .by$names
+    .data <- step_group(.data, .by$names)
   }
 
   dots <- as.list(enquos(..., .named = TRUE))

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -189,9 +189,11 @@ test_that("Using `.by` doesn't group prior step, #439", {
     select(x, y) %>%
     mutate(row_num = row_number(), .by = y) %>%
     filter(row_num < 3, .by = y) %>%
-    as_tibble()
+    as.data.frame()
 
-  # Note: data.table would duplicate y name since it is in `by` and in `select(x, y)`
+  # Note: Why this test catches the potential error...
+  # data.table allows duplicate column names. If using `.by` affected the `select` step,
+  # data.table would duplicate the "y" column. and there would therefore be two "y" columns.
   expect_equal(names(res), c("x", "y", "row_num"))
 })
 

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -192,8 +192,9 @@ test_that("Using `.by` doesn't group prior step, #439", {
     as.data.frame()
 
   # Note: Why this test catches the potential error...
-  # data.table allows duplicate column names. If using `.by` affected the `select` step,
-  # data.table would duplicate the "y" column. and there would therefore be two "y" columns.
+  # data.frames/data.tables allow duplicate column names.
+  # If using `.by` affected the `select` step, data.table would duplicate the "y" column.
+  # and there would therefore be two "y" columns in the result.
   expect_equal(names(res), c("x", "y", "row_num"))
 })
 

--- a/tests/testthat/test-step-mutate.R
+++ b/tests/testthat/test-step-mutate.R
@@ -183,6 +183,18 @@ test_that("works with `.by`", {
   expect_true(length(step$groups) == 0)
 })
 
+test_that("Using `.by` doesn't group prior step, #439", {
+  dt <- lazy_dt(data.table(x = 1:3, y = c(1, 1, 2), z = 1), "DT")
+  res <- dt %>%
+    select(x, y) %>%
+    mutate(row_num = row_number(), .by = y) %>%
+    filter(row_num < 3, .by = y) %>%
+    as_tibble()
+
+  # Note: data.table would duplicate y name since it is in `by` and in `select(x, y)`
+  expect_equal(names(res), c("x", "y", "row_num"))
+})
+
 # var = NULL -------------------------------------------------------------
 
 test_that("var = NULL works when var is in original data", {


### PR DESCRIPTION
Closes #439

Note: This is just a slight continuation of #443 that takes care of more cases where the error occurred.