### PR TITLE
Use `pak` for dev install

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -38,8 +38,8 @@ install.packages("dtplyr")
 Or try the development version from GitHub with:
 
 ```R
-# install.packages("devtools")
-devtools::install_github("tidyverse/dtplyr")
+# install.packages("pak")
+pak::pak("tidyverse/dtplyr")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ install.packages("dtplyr")
 Or try the development version from GitHub with:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("tidyverse/dtplyr")
+# install.packages("pak")
+pak::pak("tidyverse/dtplyr")
 ```
 
 ## Usage


### PR DESCRIPTION
Closes #444 

FYI @eutwt I'm just going to merge this one once checks pass. It's just a small `README` update to use `pak::pak()` for dev install.