### PR TITLE
Don't squash accessor calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@
 
 * `.by` no longer alters grouping in prior steps (#439)
 
+* Arguments to `$` calls are no longer prepended with `..`  (#434)
+
 # dtplyr 1.3.1
 
 * Fix for failing R CMD check.

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@
 
 * `.by` no longer alters grouping in prior steps (#439)
 
-* Arguments to `$` calls are no longer prepended with `..`  (#434)
+* Arguments to `$` and `[[` calls are no longer prepended with `..`  (#434)
 
 # dtplyr 1.3.1
 

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -270,7 +270,7 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x[[1]] <- expr(rleid)
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)
     x
-  } else if (is_call(x, "$") && !is_mask_pronoun(x)) {
+  } else if (is_call(x, c("$", "[[")) && !is_mask_pronoun(x)) {
     x
   } else {
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -270,6 +270,8 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x[[1]] <- expr(rleid)
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)
     x
+  } else if (is_call(x, "$") && !is_mask_pronoun(x)) {
+    x
   } else {
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)
     x

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -270,7 +270,7 @@ dt_squash_call <- function(x, env, data, j = TRUE) {
     x[[1]] <- expr(rleid)
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)
     x
-  } else if (is_call(x, c("$", "[[")) && !is_mask_pronoun(x)) {
+  } else if (is_call(x, c("$", "[["))) {
     x
   } else {
     x[-1] <- lapply(x[-1], dt_squash, env, data, j = j)

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -33,6 +33,15 @@ test_that("unless we're operating in the global environment", {
   expect_equal(capture_dot(dt, !!quo, j = FALSE), quote(x + n))
 })
 
+test_that("ignores calls to `$`, #434", {
+  df <- tibble(length = 1)
+
+  step <- lazy_dt(tibble(x = 1:3), "DT") %>%
+    mutate(y = df$length)
+
+  expect_equal(show_query(step), expr(copy(DT)[, `:=`(y = df$length)]))
+})
+
 test_that("using environment of inlined quosures", {
   dt <- lazy_dt(data.frame(x = 1:10, y = 1:10))
 

--- a/tests/testthat/test-tidyeval.R
+++ b/tests/testthat/test-tidyeval.R
@@ -33,13 +33,18 @@ test_that("unless we're operating in the global environment", {
   expect_equal(capture_dot(dt, !!quo, j = FALSE), quote(x + n))
 })
 
-test_that("ignores calls to `$`, #434", {
+test_that("ignores accessor calls, #434", {
   df <- tibble(length = 1)
 
   step <- lazy_dt(tibble(x = 1:3), "DT") %>%
     mutate(y = df$length)
 
   expect_equal(show_query(step), expr(copy(DT)[, `:=`(y = df$length)]))
+
+  step <- lazy_dt(tibble(x = 1:3), "DT") %>%
+    mutate(y = df[["length"]])
+
+  expect_equal(show_query(step), expr(copy(DT)[, `:=`(y = df[["length"]])]))
 })
 
 test_that("using environment of inlined quosures", {


### PR DESCRIPTION
Closes #434

This seemed like the most straightforward solution. There's no way of knowing what objects are being accessed or what the possible name conflicts are.