### PR TITLE
data frame splicing in `j`

### DIFF
--- a/R/step-subset-summarise.R
+++ b/R/step-subset-summarise.R
@@ -43,7 +43,7 @@ summarise.dtplyr_step <- function(.data, ..., .by = NULL, .groups = NULL) {
     out <- step_subset_j(
       .data,
       vars = union(group_vars, names(dots)),
-      j = call2(".", !!!dots),
+      j = get_j(dots),
       by = by
     )
   }

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -85,6 +85,8 @@ get_j <- function(dots) {
     return(dots[[1]])
   }
 
+  # create an expression with base functions which gives the same value as
+  # purrr::list_flatten(list(<dots>)) when evaluated
   names(dots)[dot_is_data_frame_call] <- ""
   dots[!dot_is_data_frame_call] <- lapply(
     dots[!dot_is_data_frame_call],

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -86,9 +86,11 @@ get_j <- function(dots) {
   }
 
   names(dots)[dot_is_data_frame_call] <- ""
-  dots[!dot_is_data_frame_call] <- lapply(dots[!dot_is_data_frame_call], function(x) {
-    call2('list', x)
-  })
+  dots[!dot_is_data_frame_call] <- lapply(
+    dots[!dot_is_data_frame_call],
+    call2,
+    .fn = "list"
+  )
   j <- call2(".", !!!dots)
   call2("unlist", j, recursive = FALSE)
 }

--- a/R/tidyeval.R
+++ b/R/tidyeval.R
@@ -401,7 +401,9 @@ is_data_frame_call <- function(dot) {
   is_call(dot, "as.tibble") ||
   is_call(dot, "as_tibble_row") ||
   is_call(dot, "as.data.frame") ||
+  is_call(dot, "data.frame") ||
   is_call(dot, "as.data.table") ||
+  is_call(dot, "data.table") ||
   is_call(dot, "tibble")
 }
 

--- a/tests/testthat/test-step-subset-summarise.R
+++ b/tests/testthat/test-step-subset-summarise.R
@@ -170,14 +170,14 @@ test_that("data.frame()-ish calls get spliced - with grouped input", {
     summarise(tibble::as_tibble_row(c(x = 1, y = 2)))
   expect_identical(
     collect(one_dot),
-    tibble(x = 1, y = 2)
+    tibble(a = 'a', x = 1, y = 2)
   )
 
   two_dots <- df %>%
     summarise(tibble::as_tibble_row(c(x = 1, y = 2)), z = 3)
   expect_identical(
     collect(two_dots),
-    tibble(x = 1, y = 2, z = 3)
+    tibble(a = 'a', x = 1, y = 2, z = 3)
   )
 
 })

--- a/tests/testthat/test-step-subset-summarise.R
+++ b/tests/testthat/test-step-subset-summarise.R
@@ -140,3 +140,45 @@ test_that("can change group vars", {
     dt %>% summarise(across(a, ~ 2)), "Column `a` doesn't exist"
   )
 })
+
+test_that("data.frame()-ish calls get spliced", {
+
+  df <- lazy_dt(data.frame(a = 'a'))
+
+  one_dot <- df %>%
+    summarise(tibble::as_tibble_row(c(x = 1, y = 2)))
+  expect_identical(
+    collect(one_dot),
+    tibble(x = 1, y = 2)
+  )
+
+  two_dots <- df %>%
+    summarise(tibble::as_tibble_row(c(x = 1, y = 2)), z = 3)
+  expect_identical(
+    collect(two_dots),
+    tibble(x = 1, y = 2, z = 3)
+  )
+
+})
+
+test_that("data.frame()-ish calls get spliced - with grouped input", {
+
+  df <- lazy_dt(data.frame(a = 'a')) %>%
+    group_by(a)
+
+  one_dot <- df %>%
+    summarise(tibble::as_tibble_row(c(x = 1, y = 2)))
+  expect_identical(
+    collect(one_dot),
+    tibble(x = 1, y = 2)
+  )
+
+  two_dots <- df %>%
+    summarise(tibble::as_tibble_row(c(x = 1, y = 2)), z = 3)
+  expect_identical(
+    collect(two_dots),
+    tibble(x = 1, y = 2, z = 3)
+  )
+
+})
+

--- a/tests/testthat/test-step-subset-summarise.R
+++ b/tests/testthat/test-step-subset-summarise.R
@@ -143,7 +143,7 @@ test_that("can change group vars", {
 
 test_that("data.frame()-ish calls get spliced", {
 
-  df <- lazy_dt(data.frame(a = 'a'))
+  df <- lazy_dt(data.frame(a = 0))
 
   one_dot <- df %>%
     summarise(tibble::as_tibble_row(c(x = 1, y = 2)))
@@ -163,21 +163,21 @@ test_that("data.frame()-ish calls get spliced", {
 
 test_that("data.frame()-ish calls get spliced - with grouped input", {
 
-  df <- lazy_dt(data.frame(a = 'a')) %>%
+  df <- lazy_dt(data.frame(a = 0)) %>%
     group_by(a)
 
   one_dot <- df %>%
     summarise(tibble::as_tibble_row(c(x = 1, y = 2)))
   expect_identical(
     collect(one_dot),
-    tibble(a = 'a', x = 1, y = 2)
+    tibble(a = 0, x = 1, y = 2)
   )
 
   two_dots <- df %>%
     summarise(tibble::as_tibble_row(c(x = 1, y = 2)), z = 3)
   expect_identical(
     collect(two_dots),
-    tibble(a = 'a', x = 1, y = 2, z = 3)
+    tibble(a = 0, x = 1, y = 2, z = 3)
   )
 
 })


### PR DESCRIPTION
closes #454

This appears to work but I'm not sure how I feel about adding it. I'm not sure if there's a better option for `j` when there's more than one `...` argument (second example below). I'm also assuming R doesn't make a copy of the elements in the inner list but haven't tested that.

Right now I only made the change for `summarise()` 

``` r
devtools::load_all('~/Documents/dtplyr')
#> ℹ Loading dtplyr

mtcars |> 
  dtplyr::lazy_dt() |> 
  dplyr::summarise(
    stats::quantile(mpg, probs = c(0.5, 0.9)) |> 
      tibble::as_tibble_row(),
    .by = cyl
  )
#> Source: local data table [3 x 3]
#> Call:   `_DT1`[, tibble::as_tibble_row(stats::quantile(mpg, probs = c(0.5, 
#>     0.9))), keyby = .(cyl)]
#> 
#>     cyl `50%` `90%`
#>   <dbl> <dbl> <dbl>
#> 1     4  26    32.4
#> 2     6  19.7  21.2
#> 3     8  15.2  18.3
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results

mtcars |> 
  dtplyr::lazy_dt() |> 
  dplyr::summarise(
    stats::quantile(mpg, probs = c(0.5, 0.9)) |> 
      tibble::as_tibble_row(),
    z = 1,
    .by = cyl
  )
#> Source: local data table [3 x 4]
#> Call:   `_DT2`[, unlist(.(tibble::as_tibble_row(stats::quantile(mpg, 
#>     probs = c(0.5, 0.9))), z = list(1)), recursive = FALSE), 
#>     keyby = .(cyl)]
#> 
#>     cyl `50%` `90%`     z
#>   <dbl> <dbl> <dbl> <dbl>
#> 1     4  26    32.4     1
#> 2     6  19.7  21.2     1
#> 3     8  15.2  18.3     1
#> 
#> # Use as.data.table()/as.data.frame()/as_tibble() to access results
```

<sup>Created on 2023-12-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>