### PR TITLE
Avoid forced copy in step_setnames() and rename_with()

### DIFF
--- a/R/step-call.R
+++ b/R/step-call.R
@@ -121,14 +121,14 @@ rename_with.dtplyr_step <- function(.data, .fn, .cols = everything(), ...) {
       "setnames",
       args = list(fn),
       vars = vars,
-      in_place = TRUE
+      in_place = !.data$implicit_copy
     )
   } else {
     out <- step_call(.data,
       "setnames",
       args = list(old_vars, fn),
       vars = vars,
-      in_place = TRUE
+      in_place = !.data$implicit_copy
     )
   }
 

--- a/R/step-setnames.R
+++ b/R/step-setnames.R
@@ -27,7 +27,7 @@ step_setnames <- function(x, old, new, in_place, rename_groups = FALSE) {
     "setnames",
     args = list(old, new),
     vars = new_vars,
-    in_place = in_place
+    in_place = in_place && !x$implicit_copy
   )
 
   if (rename_groups) {

--- a/tests/testthat/_snaps/step-call-pivot_wider.md
+++ b/tests/testthat/_snaps/step-call-pivot_wider.md
@@ -40,8 +40,8 @@
       * `x` -> `x...2`
     Output
       Source: local data table [1 x 2]
-      Call:   setnames(dcast(copy(DT), formula = x ~ lab, value.var = "val"), 
-          1:2, c("x...1", "x...2"))
+      Call:   setnames(dcast(DT, formula = x ~ lab, value.var = "val"), 1:2, 
+          c("x...1", "x...2"))
       
         x...1 x...2
         <dbl> <dbl>

--- a/tests/testthat/test-step-call.R
+++ b/tests/testthat/test-step-call.R
@@ -31,6 +31,15 @@ test_that("simple calls generate expected translations", {
   )
 })
 
+test_that("mutable object is not copied", {
+  dt <- lazy_dt(data.table(x = 1, y = 1, z = 1), "DT", immutable = FALSE)
+
+  expect_equal(
+    dt %>% rename(b = y) %>% show_query(),
+    expr(setnames(DT, "y", "b"))
+  )
+})
+
 test_that("vars set correctly", {
   dt <- lazy_dt(data.frame(x = 1:3, y = 1:3))
   expect_equal(dt %>% rename(a = x) %>% .$vars, c("a", "y"))


### PR DESCRIPTION
`step_setnames()` and `rename_with()` will now not force a `copy()` if `lazy_dt()` was called with `immutable = FALSE`. In line with how `mutate()` and `relocate()` already behave.

Added test for `rename()` with `immutable = FALSE`. Updated expected result of `pivot_wider()` test, as the call to `step_setnames()` triggered an unnecessary `copy()` there too, which is now also avoided.

Fixes #485 